### PR TITLE
ci: use centralized .github repo workflows

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,0 +1,21 @@
+name: CI Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  ci-tests:
+    uses: observeinc/.github/.github/workflows/terraform-observe_scheduler.yaml@main
+    secrets: inherit
+    with:
+      # you can opt out of ci-tests scheduled by adding a list of "jobs" ids for the 
+      # tests that you want to skip, like so...
+      # skip: '{"jobs": ["conventional-commits", "single-commit"]}'
+      skip: '{}'
+
+  pre-commits:
+    uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit.yaml@main

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,0 +1,13 @@
+name: Pre-commit auto-update
+
+on:
+  # every day at midnight
+  schedule:
+    - cron: "0 0 * * *"
+  # on demand  
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit-autoupdate.yaml@main
+    secrets: inherit

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,10 @@
+name: Publish prerelease
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: observeinc/.github/.github/workflows/terraform-observe_prerelease.yaml@main
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,8 @@
+name: Release and push
+on:
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: observeinc/.github/.github/workflows/terraform-observe_release.yaml@main
+    secrets: inherit

--- a/.github/workflows/sync-from-template-repo.yaml
+++ b/.github/workflows/sync-from-template-repo.yaml
@@ -1,0 +1,19 @@
+name: Sync to Template Repo
+
+on:
+  # Run at 9am PST each Monday
+  workflow_dispatch:
+  schedule:
+    - cron: "0 16 * * 1"
+
+jobs:
+  template-sync:
+    uses: observeinc/.github/.github/workflows/terraform-observe_sync-from-template-repo.yaml@main
+    secrets: inherit
+    with:
+      BASE_BRANCH: "main"
+      HEAD_BRANCH: "chore/sync-from-template"
+      GIT_AUTHOR_NAME: "${{ github.repository_owner }}"
+      GIT_AUTHOR_EMAIL: "${{ github.repository_owner }}@users.noreply.github.com"
+      REPO_TEMPLATE: "observeinc/terraform-observe-example"
+      THIS_REPO: "${{ github.repository }}"


### PR DESCRIPTION
## What does this PR do?

Replaces current workflows with those defined in [the central .github repo](https://github.com/observeinc/.github)

See [full description of what these central workflows look like here](https://github.com/observeinc/terraform-observe-example/pull/10). 

## Motivation

Make CI maintenance easier

## Testing

These workflows [have been tested in other repos](https://github.com/observeinc/terraform-observe-estib-test2/actions/runs/2321788481) successfully