### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @arthur-observe @slobsv
+


### PR DESCRIPTION
## What does this PR do?

Creates a `CODEOWNERS` file so that PRs don't go stale

Today we are setting 2 individuals as owners (with primary and secondary designations) and later we'll move to team ownership with a rotation for reviews.

## Testing

Tested on [another repo first](https://github.com/observeinc/terraform-observe-telegraf/pull/20) and it worked nicely: review is requested automatically without limiting the merges. 