### PR TITLE
feat:  CloudSQL - creation of cloud sql datasets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @arthur-observe @slobsv
+

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -19,3 +19,4 @@ jobs:
 
   pre-commits:
     uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit.yaml@main
+    secrets: inherit

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -9,5 +9,6 @@ on:
 
 jobs:
   auto-update:
-    uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit-autoupdate.yaml@main
+    if: github.repository == 'observeinc/terraform-observe-example'
+    uses: observeinc/.github/.github/workflows/pre-commit-autoupdate.yaml@main
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+*.lock.hcl
 
 # Include override files you do wish to add to version control using negated pattern
 #
@@ -27,3 +28,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+.DS_Store
+*.json
+*.tf-e
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.71.0
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.vscode/dryrun.log
+++ b/.vscode/dryrun.log
@@ -1,0 +1,1 @@
+make --dry-run --always-make --keep-going --print-directory

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .PHONY: changelog release
-.PHONY: precommit-dependencies changelog-patch release-patch
 
 TMP:=.test.zip
 LEGACY_BUCKET:=observeinc
@@ -17,21 +16,8 @@ s3:
 	aws s3 cp $(TMP) s3://$(BUCKET)/artifacts/v1/modules/namespace=observeinc/name=$(MODULE_NAME)/provider=$(MODULE_SYSTEM)/version=$(MODULE_VERSION)/observeinc-$(MODULE_NAME)-$(MODULE_SYSTEM)-$(MODULE_VERSION).zip
 	rm $(TMP)
 
+list-tests:
+	@scripts/tftest list
 
-precommit-dependencies:
-	# github actions helper
-	pip install pre-commit
-	curl -L "$(shell curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest |grep -o -E "https://.+?linux-amd64.tar.gz")" > terraform-docs.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/ && rm terraform-docs.tar.gz
-	curl -L "$(shell curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-
-changelog:
-	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
-
-release:
-	semtag final -s minor
-
-changelog-patch:
-	git-chglog -o CHANGELOG.md --next-tag `semtag final -s patch -o`
-
-release-patch:
-	semtag final -s patch
+test:
+	@scripts/tftest run $(filter-out $@,$(MAKECMDGOALS))

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ module "google" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudfunctions"></a> [cloudfunctions](#module\_cloudfunctions) | ./service/cloudfunctions | n/a |
+| <a name="module_cloudsql"></a> [cloudsql](#module\_cloudsql) | ./service/cloudsql | n/a |
 
 ## Resources
 
@@ -60,6 +61,7 @@ module "google" {
 | <a name="input_datastream"></a> [datastream](#input\_datastream) | Datastream to derive OTEL resources from. | `object({ dataset = string })` | n/a | yes |
 | <a name="input_enable_service_all"></a> [enable\_service\_all](#input\_enable\_service\_all) | Enable all services.<br>If enabled, all services that are not explicitly set to false will be<br>configured. | `bool` | `false` | no |
 | <a name="input_enable_service_cloudfunctions"></a> [enable\_service\_cloudfunctions](#input\_enable\_service\_cloudfunctions) | Enable Cloud Functions service. | `bool` | `null` | no |
+| <a name="input_enable_service_cloudsql"></a> [enable\_service\_cloudsql](#input\_enable\_service\_cloudsql) | Enable Cloud SQL service. | `bool` | `null` | no |
 | <a name="input_feature_flags"></a> [feature\_flags](#input\_feature\_flags) | Toggle features which are being rolled out or phased out. | `map(bool)` | `{}` | no |
 | <a name="input_freshness_default"></a> [freshness\_default](#input\_freshness\_default) | Default dataset freshness. Can be overridden with freshness input | `string` | `"1m"` | no |
 | <a name="input_max_expiry"></a> [max\_expiry](#input\_max\_expiry) | Maximum expiry time for resources. | `string` | `"4h"` | no |
@@ -86,3 +88,69 @@ module "google" {
 ## License
 
 Apache 2 Licensed. See LICENSE for full details.
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_observe"></a> [observe](#requirement\_observe) | ~> 0.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_observe"></a> [observe](#provider\_observe) | 0.6.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cloudfunctions"></a> [cloudfunctions](#module\_cloudfunctions) | ./service/cloudfunctions | n/a |
+| <a name="module_cloudsql"></a> [cloudsql](#module\_cloudsql) | ./service/cloudsql | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| observe_dataset.audit_logs | resource |
+| observe_dataset.base_asset_inventory_records | resource |
+| observe_dataset.base_pubsub_events | resource |
+| observe_dataset.distribution_metrics | resource |
+| observe_dataset.iam_policy_asset_inventory_records | resource |
+| observe_dataset.logs | resource |
+| observe_dataset.metric_points | resource |
+| observe_dataset.metrics | resource |
+| observe_dataset.resource_asset_inventory_records | resource |
+| observe_dataset.string_metrics | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_datastream"></a> [datastream](#input\_datastream) | Datastream to derive OTEL resources from. | `object({ dataset = string })` | n/a | yes |
+| <a name="input_enable_service_all"></a> [enable\_service\_all](#input\_enable\_service\_all) | Enable all services.<br>If enabled, all services that are not explicitly set to false will be<br>configured. | `bool` | `false` | no |
+| <a name="input_enable_service_cloudfunctions"></a> [enable\_service\_cloudfunctions](#input\_enable\_service\_cloudfunctions) | Enable Cloud Functions service. | `bool` | `null` | no |
+| <a name="input_enable_service_cloudsql"></a> [enable\_service\_cloudsql](#input\_enable\_service\_cloudsql) | Enable Cloud SQL service. | `bool` | `null` | no |
+| <a name="input_feature_flags"></a> [feature\_flags](#input\_feature\_flags) | Toggle features which are being rolled out or phased out. | `map(bool)` | `{}` | no |
+| <a name="input_freshness_default"></a> [freshness\_default](#input\_freshness\_default) | Default dataset freshness. Can be overridden with freshness input | `string` | `"1m"` | no |
+| <a name="input_max_expiry"></a> [max\_expiry](#input\_max\_expiry) | Maximum expiry time for resources. | `string` | `"4h"` | no |
+| <a name="input_max_time_diff"></a> [max\_time\_diff](#input\_max\_time\_diff) | Maximum time difference for processing time window. | `string` | `"4h"` | no |
+| <a name="input_name_format"></a> [name\_format](#input\_name\_format) | Format string to use for dataset names. Override to introduce a prefix or suffix. | `string` | `"%s"` | no |
+| <a name="input_service_name_formats"></a> [service\_name\_formats](#input\_service\_name\_formats) | Override nested name\_format for enabled services | `map(string)` | `{}` | no |
+| <a name="input_services"></a> [services](#input\_services) | Map of services to enable. | `map(bool)` | `{}` | no |
+| <a name="input_workspace"></a> [workspace](#input\_workspace) | Workspace to apply module to. | `object({ oid = string })` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_asset_inventory_records"></a> [asset\_inventory\_records](#output\_asset\_inventory\_records) | n/a |
+| <a name="output_audit_logs"></a> [audit\_logs](#output\_audit\_logs) | n/a |
+| <a name="output_cloud_functions"></a> [cloud\_functions](#output\_cloud\_functions) | n/a |
+| <a name="output_iam_policy_asset_inventory_records"></a> [iam\_policy\_asset\_inventory\_records](#output\_iam\_policy\_asset\_inventory\_records) | n/a |
+| <a name="output_logs"></a> [logs](#output\_logs) | n/a |
+| <a name="output_metrics"></a> [metrics](#output\_metrics) | n/a |
+| <a name="output_pubsub_events"></a> [pubsub\_events](#output\_pubsub\_events) | n/a |
+| <a name="output_resource_asset_inventory_records"></a> [resource\_asset\_inventory\_records](#output\_resource\_asset\_inventory\_records) | n/a |
+<!-- END_TF_DOCS -->

--- a/enable.tf
+++ b/enable.tf
@@ -5,6 +5,13 @@ locals {
     lookup(var.services, "cloudfunctions", false)
   )
   name_format_cloudfunctions = lookup(var.service_name_formats, "cloudfunctions", "Cloud Functions %s")
+
+  enable_service_cloudsql = (
+    var.enable_service_cloudsql == true ||
+    (var.enable_service_all == true && var.enable_service_cloudsql != false) ||
+    lookup(var.services, "cloudsql", false)
+  )
+  name_format_cloudsql = lookup(var.service_name_formats, "cloudsql", "Cloud SQL %s")
 }
 
 module "cloudfunctions" {
@@ -19,3 +26,17 @@ module "cloudfunctions" {
 
   google = local.base_module
 }
+
+module "cloudsql" {
+  count = local.enable_service_cloudsql ? 1 : 0
+
+  source            = "./service/cloudsql"
+  workspace         = var.workspace
+  name_format       = format(var.name_format, local.name_format_cloudsql)
+  max_expiry        = var.max_expiry
+  freshness_default = var.freshness_default
+  feature_flags     = var.feature_flags
+
+  google = local.base_module
+}
+

--- a/main.tf
+++ b/main.tf
@@ -117,6 +117,9 @@ resource "observe_dataset" "resource_asset_inventory_records" {
     input    = "events"
     pipeline = <<-EOF
       filter not is_null(resource)
+
+      make_col ttl: case(deleted, 1ns, true, ${var.max_expiry})
+
       pick_col 
         time,
         deleted,
@@ -127,7 +130,8 @@ resource "observe_dataset" "resource_asset_inventory_records" {
         discovery_name:string(resource.discovery_name),
         location:string(resource.location),
         parent:string(resource.parent),
-        version:string(resource.version)
+        version:string(resource.version),
+        ttl
     EOF
   }
 }

--- a/scripts/tftest
+++ b/scripts/tftest
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# tftest: utility for testing Observe terraform modules
+#
+# Use this script to manage the setup/teardown of a test submodule.
+#
+set -o errexit
+set -o pipefail
+
+COMMANDS=(
+    list
+    run
+)
+
+ERROR() { echo "::error::$*"; }
+INFO() { echo "::info::$*"; }
+DEBUG() { test -z "$VERBOSE" || echo "::debug::$*"; }
+
+check_env() {
+    if [[ -z $OBSERVE_CUSTOMER || -z $OBSERVE_DOMAIN || -z $OBSERVE_USER_EMAIL || -z $OBSERVE_USER_PASSWORD ]]; then
+      ERROR 'one or more OBSERVE_ environment variables are undefined'
+      exit 1
+    fi
+}
+
+usage() {
+    echo "tftest: utility for testing Observe terraform modules."
+    echo
+    echo "${B}$0 [-hvn] <command>${r}"
+    echo "  -h     this help"
+    echo
+    echo "  ${B}list${r}          List tests"
+    echo "  ${B}run <testdir>${r} Run test. If no dir provided, run all tests serially."
+    echo
+    exit 1
+}
+
+needle_in_haystack() {
+    local needle="$1"
+    shift
+    for arg in "$@"; do
+        [[ "${needle}" = "${arg}" ]] && return 0
+    done
+    return 1
+}
+
+do_list() {
+  DIRS="$(find . -path "*tftests/*" ! -path "*.terraform*" -type d )"
+  echo $DIRS
+}
+
+run_single() {
+  CMD="terraform -chdir=${1}"
+
+  cleanup() {
+      if [ "$1" != "0" ]; then
+          ERROR "encountered an error, running terraform destroy for cleanup"
+          ERROR "exit code $1 occurred on line $2"
+      fi
+      ${CMD} destroy -auto-approve -input=false
+  }
+
+  ${CMD} init
+  trap 'cleanup $? $LINENO' ERR
+  ${CMD} apply -auto-approve -input=false
+  ${CMD} destroy -auto-approve -input=false
+}
+
+do_run() {
+    check_env
+    DIRS=$@
+    if [ $# -eq 0 ]; then
+        DIRS=$(do_list)
+    fi
+
+    for DIR in $DIRS
+    do
+        run_single ${DIR}
+    done
+}
+
+while getopts 'h' OPTION; do
+    case $OPTION in
+        *) usage ;;
+    esac
+done
+shift $((OPTIND-1)); OPTIND=1
+
+if [[ $# -lt 1 ]]; then usage; fi # Requires 1+ arguments
+COMMAND="$1"
+shift
+
+if ! needle_in_haystack "${COMMAND}" "${COMMANDS[@]}"; then
+    # Only run the given command if it actually exists
+    echo "Unknown commmand '$COMMAND'"
+    echo
+    usage
+fi
+
+"do_${COMMAND//-/_}" "$@"

--- a/service/cloudsql/cloudsqlmetricslocal.tf
+++ b/service/cloudsql/cloudsqlmetricslocal.tf
@@ -1,0 +1,842 @@
+locals {
+  cloudsql_metrics = {
+    "cloudsql.googleapis.com/database/active_directory/domain_reachable" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the instance is able to ping a domain controller from the connected Managed Active Directory domain. If false, Windows Authentication may not work as expected. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/active_directory/instance_available" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the instance is currently available using Windows Authentication. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/auto_failover_request_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta of number of instance auto-failover requests. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/available_for_failover" = {
+      type        = "gauge"
+      description = <<-EOF
+          This is greater than 0 if the failover operation is available on the instance. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/cpu/reserved_cores" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of cores reserved for the database. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/cpu/usage_time" = {
+      type        = "delta"
+      description = <<-EOF
+          Cumulative CPU usage time in seconds. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/cpu/utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+          Current CPU utilization represented as a percentage of the reserved CPU that is currently in use. Values are typically numbers between 0.0 and 1.0 but might exceed 1.0. Charts display the values as a percentage between 0% and 100% or more. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/disk/bytes_used" = {
+      type        = "gauge"
+      description = <<-EOF
+          Data utilization in bytes. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/disk/bytes_used_by_data_type" = {
+      type        = "gauge"
+      description = <<-EOF
+          Data utilization in bytes. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/disk/quota" = {
+      type        = "gauge"
+      description = <<-EOF
+          Maximum data disk size in bytes. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/disk/read_ops_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of data disk read IO operations. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/disk/utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+          The fraction of the disk quota that is currently in use. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/disk/write_ops_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of data disk write IO operations. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/instance_state" = {
+      type        = "gauge"
+      description = <<-EOF
+          The current serving state of the Cloud SQL instance.
+Because there are seven possible states, seven data points are returned.
+Each of them has a different field value representing each state.
+Only the one that matches the current state of the instance is TRUE. All the others are FALSE.
+The state can be one of the following:
+RUNNING:  The instance is running, or is ready to run when accessed.
+SUSPENDED: The instance is not available, for example due to problems with billing.
+RUNNABLE: The instance has been stopped by owner. It is not currently running, but it's ready to be restarted.
+PENDING_CREATE: The instance is being created.
+MAINTENANCE: The instance is down for maintenance.
+FAILED: The instance creation failed.
+UNKNOWN_STATE: The state of the instance is unknown. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/memory/quota" = {
+      type        = "gauge"
+      description = <<-EOF
+          Maximum RAM size in bytes. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/memory/total_usage" = {
+      type        = "gauge"
+      description = <<-EOF
+          Total RAM usage in bytes including buffer cache. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/memory/usage" = {
+      type        = "gauge"
+      description = <<-EOF
+          RAM usage in bytes. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/memory/utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+          The fraction of the memory quota that is currently in use. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_dirty" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of unflushed pages in the InnoDB buffer pool. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_free" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of unused pages in the InnoDB buffer pool. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_total" = {
+      type        = "gauge"
+      description = <<-EOF
+          Total number of pages in the InnoDB buffer pool. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_data_fsyncs" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of InnoDB fsync calls. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_os_log_fsyncs" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of InnoDB fsync calls to the log file. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_pages_read" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of InnoDB pages read. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/innodb_pages_written" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of InnoDB pages written. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/queries" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of statements executed by the server. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/questions" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of statements executed by the server sent by the client. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/received_bytes_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of bytes received by MySQL process. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/available_for_failover" = {
+      type        = "gauge"
+      description = <<-EOF
+          This is greater than 0 if the failover operation is available on the master instance.master. The metric is deprecated.  Please use cloudsql.googleapis.com/database/available_for_failover instead Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "DEPRECATED"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/last_io_errno" = {
+      type        = "gauge"
+      description = <<-EOF
+          The error number of the most recent error that caused the I/O thread to stop. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/last_sql_errno" = {
+      type        = "gauge"
+      description = <<-EOF
+          The error number of the most recent error that caused the SQL thread to stop. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/seconds_behind_master" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of seconds the read replica is behind its primary approximation. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/slave_io_running" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the I/O thread for reading the primary's binary log is running. Possible values are Yes, No and Connecting. Sampled every 60s and may take up to 60s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/slave_io_running_state" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the I/O thread for reading the primary's binary log is running. Possible values are Yes, No and Connecting, and the values are exposed through the 'state' field. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/slave_sql_running" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the SQL thread for executing events in the relay log is running. Sampled every 60s and may take up to 60s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/replication/slave_sql_running_state" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether the SQL thread for executing events in the relay log is running. Possible values are Yes / No, and the values are exposed through the 'state' field. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/mysql/sent_bytes_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of bytes sent by MySQL process. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/network/connections" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/network/received_bytes_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of bytes received through the network. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/network/sent_bytes_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of bytes sent through the network. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/blocks_read_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Number of disk blocks read by this database. The source field distingushes actual reads from disk versus reads from buffer cache. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/deadlock_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Number of deadlocks detected for this database. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/external_sync/initial_sync_complete" = {
+      type        = "gauge"
+      description = <<-EOF
+          Whether all databases on the Postgres External Server ES replica have completed the initial sync and are replicating changes from the source. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/external_sync/max_replica_byte_lag" = {
+      type        = "gauge"
+      description = <<-EOF
+          Replication lag in bytes for Postgres External Server ES replicas. Aggregated across all DBs on the replica. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/execution_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated query execution time per user per database. This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/io_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated IO time per user per database.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/latencies" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Query latency distribution per user per database.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/lock_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated lock wait time per user per database.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/row_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Total number of rows affected during query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/aggregate/shared_blk_access_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Shared blocks regular tables and indexed accessed by statement execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated execution times per user per database per query.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/io_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated IO time per user per database per query.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/latencies" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Query latency distribution per user per database per query.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated lock wait time per user per database per query.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/row_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Total number of rows affected during query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/perquery/shared_blk_access_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Shared blocks regular tables and indexed accesssed by statement execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/execution_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated execution times per user per database per tag.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/io_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated IO write time per user per database per tag.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/latencies" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Query latency distribution per user per database per tag.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/lock_time" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Accumulated lock wait time per user per database per tag.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/row_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Total number of rows affected during query execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/insights/pertag/shared_blk_access_count" = {
+      type        = "cumulativeCounter"
+      description = <<-EOF
+          Shared blocks regular tables and indexed accessed by statement execution.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/num_backends" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of connections to the Cloud SQL PostgreSQL instance. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/num_backends_by_state" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of connections to the Cloud SQL PostgreSQL instance, grouped by its state. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/replication/replica_byte_lag" = {
+      type        = "gauge"
+      description = <<-EOF
+          Replication lag in bytes. Reported from the master per replica. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/transaction_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of number of transactions. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/transaction_id_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of transaction ID. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/transaction_id_utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+          Current utilization represented as a percentage of transaction IDs consumed by the Cloud SQL PostgreSQL instance. Values are typically numbers between 0.0 and 1.0. Charts display the values as a percentage between 0% and 100%. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/postgresql/tuple_size" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of tuples rows in the database. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/tuples_processed_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Number of tuplesrows processed for a given database for operations like  insert, update or delete. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/postgresql/vacuum/oldest_transaction_age" = {
+      type        = "gauge"
+      description = <<-EOF
+          Age of the oldest transaction yet to be vacuumed in the Cloud SQL PostgreSQL instance, measured in number of transactions that have happened since the oldest transaction. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/replication/log_archive_failure_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Number of failed attempts for archiving replication log files. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/replication/log_archive_success_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Number of successful attempts for archiving replication log files. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/replication/network_lag" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates time taken from primary binary log to IO thread on replica. Only applicable to replicas. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/replication/replica_lag" = {
+      type        = "gauge"
+      description = <<-EOF
+          Number of seconds the read replica is behind its primary approximation. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/replication/state" = {
+      type        = "gauge"
+      description = <<-EOF
+          The current serving state of replication. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "BETA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/sqlserver/audits_size" = {
+      type        = "gauge"
+      description = <<-EOF
+          Tracks the size in bytes of stored SQLServer audit files on an instance. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/sqlserver/audits_upload_count" = {
+      type        = "delta"
+      description = <<-EOF
+          Counts total number of SQLServer audit file uploads to a GCS bucket and whether or not an upload was successful. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/sqlserver/external_sync/primary_to_replica_connection_health" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates whether there is connectivity from Primary to the Replica to push replication updates. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "ALPHA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = false
+    },
+    "cloudsql.googleapis.com/database/state" = {
+      type        = "gauge"
+      description = <<-EOF
+          The current serving state of the Cloud SQL instance. This can be one of the following:
+RUNNING:  The instance is *expected* to be running. If an instance experiences unplanned non-maintenance downtime, the state will still be RUNNING, but the database/up metric will report 0.
+SUSPENDED: The instance is not available, for example due to problems with billing.
+RUNNABLE: The instance has been stopped by owner. It is not currently running, but it's ready to be restarted.
+PENDING_CREATE: The instance is being created.
+MAINTENANCE: The instance is down for maintenance.
+FAILED: The instance creation failed or an operation left the instance in an unknown bad state.
+UNKNOWN_STATE: The state of the instance is unknown. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/up" = {
+      type        = "gauge"
+      description = <<-EOF
+          Indicates if the server is up or not. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+    "cloudsql.googleapis.com/database/uptime" = {
+      type        = "delta"
+      description = <<-EOF
+          Delta count of the time in seconds the instance has been running. Sampled every 60s and may take up to 210s to display.
+      EOF
+      launchStage = "GA"
+      rollup      = "avg"
+      aggregate   = "sum"
+      active      = true
+    },
+  }
+}

--- a/service/cloudsql/createMetricsLocal.sh
+++ b/service/cloudsql/createMetricsLocal.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Directions to use:
+# Go to https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors/list
+# Use Try this method dialog
+# Enter parameters for the API you want - list of metrics is here - https://cloud.google.com/monitoring/api/metrics_gcp
+# copy application/json response into descriptors.json
+
+# For cloudsql metrics
+# name = projects/terraflood-345116
+# filter = metric.type = starts_with("cloudsql.googleapis.com/database/")
+
+# For compute metrics
+# name = projects/terraflood-345116
+# filter = metric.type = starts_with("compute.googleapis.com/")
+
+# to call script - ./createMetricsLocal.sh --input_file cloudsqldescriptors.json --output_file cloudsqlmetricslocal.tf
+# to call script - ./createMetricsLocal.sh --input_file computedescriptors.json --output_file computemetricslocal.tf
+
+# Defaults
+input_file=descriptors.json
+output_file=metricslocal.tf
+
+# Process input flags
+    while [ $# -gt 0 ]; do
+    echo "required inputs $1 $2 $# "
+      case "$1" in
+        --input_file)
+          input_file="$2"
+          ;;
+        --output_file)
+          output_file="$2"
+          ;;
+        *)
+          
+      esac
+      shift
+      shift
+    done
+
+# Files used
+echo "Input file = $input_file"
+echo "Output file = $output_file"
+
+# create terraform file
+# super handy reference - https://stedolan.github.io/jq/manual/
+
+# jq creates object for every metric in terraform local variable but sets active to false for any metric that is not GA which is used as a filter when defining metrics
+
+echo "locals {" > "$output_file";
+echo " cloudsql_metrics = {" >> "$output_file";
+
+jq -r 'def activeFunc: if . =="GA" then "true" else "false" end; 
+        def metricCaseFunc: . |= ascii_downcase; 
+        def metricTypeFunc: if . == "cumulative" then "cumulativeCounter" else . end; 
+        def sampleFunc: if . | has("samplePeriod") then " Sampled every " + .samplePeriod + " and may take up to " + .ingestDelay + " to display." else "" end;
+    .metricDescriptors[] | 
+    "\"" + (.name | capture("projects/terraflood-345116/metricDescriptors/(?<idontwanthis>.*)") | .idontwanthis) + "\" = { 
+        type = \"" + (.metricKind | metricCaseFunc | metricTypeFunc) + "\" 
+        description = <<-EOF
+          " + (.description ) + (.metadata | sampleFunc ) + "
+      EOF
+        launchStage = \"" + (.launchStage) + "\"
+        rollup      = \"avg\"
+        aggregate   = \"sum\"
+        active      = " + (.launchStage | activeFunc) +
+        "
+        },"
+    ' "$input_file" >> "$output_file";
+
+echo "}" >> "$output_file";
+
+echo "}" >> "$output_file";
+
+# certain characters make terraform explode
+# This tends to be super painful to debug export TF_LOG=DEBUG; terraform apply might help
+sed -i'' -e 's/>/greater than/g; s/(//g; s/)//g; s/&/and/g;' "$output_file"
+
+# fmt file
+terraform fmt "$output_file"
+
+# terraform might be able to read the json itself - terraform-observe-promethius

--- a/service/cloudsql/logs.tf
+++ b/service/cloudsql/logs.tf
@@ -1,0 +1,46 @@
+resource "observe_dataset" "sql_logs" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Logs")
+  freshness = var.freshness_default
+
+  inputs = {
+    "logs" = var.google.logs.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resourceType = "cloudsql_database"
+
+      make_col 
+        database_id:string(resourceLabels.database_id),
+        project_id:string(resourceLabels.project_id),
+        region:string(resourceLabels.region)
+
+      pick_col 
+        timestamp,
+        receiveTimestamp,
+        logName,
+        severity,
+        textPayload,
+        protoPayload,
+        project_id,
+        region,
+        database_id
+    EOF
+  }
+}
+
+resource "observe_link" "sql_logs" {
+  workspace = var.workspace.oid
+  source    = observe_dataset.sql_logs.oid
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+
+  for_each = {
+    "Database" = {
+      target = observe_dataset.cloudsql.oid
+      fields = ["project_id", "region", "database_id"]
+    }
+  }
+}

--- a/service/cloudsql/main.tf
+++ b/service/cloudsql/main.tf
@@ -1,0 +1,47 @@
+
+locals {
+  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  # tflint-ignore: terraform_unused_declarations
+  enable_monitors = lookup(var.feature_flags, "monitors", true)
+}
+
+resource "observe_dataset" "cloudsql" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Instance")
+  freshness = var.freshness_default
+
+  inputs = {
+    "events" = var.google.resource_asset_inventory_records.oid
+  }
+
+  # https://cloud.google.com/sql/docs
+  stage {
+    input    = "events"
+    pipeline = <<-EOF
+      filter asset_type = "sqladmin.googleapis.com/Instance"
+      make_col
+        assetInventoryName:name,
+        name:string(data.name)
+      make_resource options(expiry:${var.max_expiry}),
+        name,
+        databaseVersion: string(data.databaseVersion),
+        label: strcat(string(data.databaseVersion),":",name),
+        databaseInstalledVersion: string(data.databaseInstalledVersion),
+        project_id: string(data.project),
+        region:  string(data.region),
+        database_id: strcat(string(data.project),":",name),
+        backendType:string(data.backendType),
+        createTime:string(data.createTime),
+        ipAddresses:string(data.ipAddresses),
+        gceZone:string(data.gceZone),
+        settings:string(data.settings),
+        primary_key(assetInventoryName),
+        valid_for(ttl)
+
+      add_key name
+      set_label label
+
+      add_key project_id, region, database_id
+    EOF
+  }
+}

--- a/service/cloudsql/metrics.tf
+++ b/service/cloudsql/metrics.tf
@@ -1,0 +1,53 @@
+resource "observe_dataset" "cloudsql_metrics" {
+  count = local.enable_metrics ? 1 : 0
+
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Metrics")
+  freshness = var.freshness_default
+
+  inputs = {
+    "metrics" = var.google.metrics.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resource_type = "cloudsql_database"
+
+      make_col 
+        database_id:string(resource_labels.database_id),
+        project_id:string(resource_labels.project_id),
+        region:string(resource_labels.region)
+
+      pick_col
+        start_time,
+        end_time,
+        metric_type,
+        metric_kind,
+        metric_labels,
+        value,
+        value_type,
+        project_id,
+        region,
+        database_id
+
+      interface "metric", metric:metric_type, value:value
+      ${join("\n\n", [for metric, options in local.cloudsql_metrics : indent(2, format("set_metric options(\n%s\n), %q", join(",\n", [for k, v in options : k == "interval" ? format("%s: %s", k, v) : format("%s: %q", k, v) if k != "active" && k != "launchStage"]), metric)) if options.active == true])}
+    EOF
+  }
+}
+
+# use var instead of prop
+resource "observe_link" "cloudsql_metrics" {
+  for_each = length(observe_dataset.cloudsql_metrics) > 0 ? {
+    "Cloud Function" = {
+      target = observe_dataset.cloudsql.oid
+      fields = ["project_id", "region", "database_id"]
+    }
+  } : {}
+
+  workspace = var.workspace.oid
+  source    = observe_dataset.cloudsql_metrics[0].oid
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+}

--- a/service/cloudsql/outputs.tf
+++ b/service/cloudsql/outputs.tf
@@ -1,0 +1,11 @@
+output "cloudsql" {
+  value = observe_dataset.cloudsql
+}
+
+output "cloudsql_logs" {
+  value = observe_dataset.sql_logs
+}
+
+output "cloudsql_metrics" {
+  value = local.enable_metrics ? observe_dataset.cloudsql_metrics[0] : null
+}

--- a/service/cloudsql/variables.tf
+++ b/service/cloudsql/variables.tf
@@ -1,0 +1,38 @@
+variable "workspace" {
+  type        = object({ oid = string })
+  description = "Workspace to apply module to."
+}
+
+variable "name_format" {
+  type        = string
+  description = "Format string to use for dataset names. Override to introduce a prefix or suffix."
+  default     = "%s"
+}
+
+variable "max_expiry" {
+  type        = string
+  description = "Maximum expiry time for resources."
+  default     = "4h"
+}
+
+variable "freshness_default" {
+  type        = string
+  description = "Default dataset freshness"
+  default     = "1m"
+}
+
+variable "feature_flags" {
+  type        = map(bool)
+  description = "Toggle features which are being rolled out or phased out."
+  default     = {}
+}
+
+variable "google" {
+  type = object({
+    resource_asset_inventory_records = object({ oid = string })
+    logs                             = object({ oid = string })
+    metrics                          = object({ oid = string })
+  })
+  description = "Google base module"
+}
+

--- a/service/cloudsql/versions.tf
+++ b/service/cloudsql/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+      version = "~> 0.6"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,11 @@ variable "enable_service_cloudfunctions" {
     Enable Cloud Functions service.
   EOF
 }
+
+variable "enable_service_cloudsql" {
+  type        = bool
+  default     = null
+  description = <<-EOF
+    Enable Cloud SQL service.
+  EOF
+}


### PR DESCRIPTION
## What does this PR do?

Adds Cloud SQL as optional service and creates datasets for cloud sql logs, metrics and resources. t

## Motivation

Build out of GCP content

## Limitations

Waiting for dashboard release to build out boards

## Testing

Created terraform or creating on demand cloudsql MYSQL / POSTGRES / SQLSERVER instances and docker commands for running ddl / dml against instances
