### PR TITLE
feat: compute  - creation of base content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+.DS_Store

--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,0 +1,1 @@
+{"buildTargets":[],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[]},"fileIndex":[]}}

--- a/.vscode/dryrun.log
+++ b/.vscode/dryrun.log
@@ -1,0 +1,1 @@
+make --dry-run --always-make --keep-going --print-directory

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/enable.tf
+++ b/enable.tf
@@ -5,6 +5,20 @@ locals {
     lookup(var.services, "cloudfunctions", false)
   )
   name_format_cloudfunctions = lookup(var.service_name_formats, "cloudfunctions", "Cloud Functions %s")
+
+  enable_service_cloudsql = (
+    var.enable_service_cloudsql == true ||
+    (var.enable_service_all == true && var.enable_service_cloudsql != false) ||
+    lookup(var.services, "cloudsql", false)
+  )
+  name_format_cloudsql = lookup(var.service_name_formats, "cloudsql", "Cloud SQL %s")
+
+  enable_service_compute = (
+    var.enable_service_compute == true ||
+    (var.enable_service_all == true && var.enable_service_compute != false) ||
+    lookup(var.services, "compute", false)
+  )
+  name_format_compute = lookup(var.service_name_formats, "compute", "Compute %s")
 }
 
 module "cloudfunctions" {
@@ -19,3 +33,33 @@ module "cloudfunctions" {
 
   google = local.base_module
 }
+
+module "cloudsql" {
+  count = local.enable_service_cloudsql ? 1 : 0
+
+  source            = "./service/cloudsql"
+  workspace         = var.workspace
+  name_format       = format(var.name_format, local.name_format_cloudsql)
+  max_expiry        = var.max_expiry
+  freshness_default = var.freshness_default
+  feature_flags     = var.feature_flags
+
+  google = local.base_module
+}
+
+module "compute" {
+  count = local.enable_service_compute ? 1 : 0
+
+  source            = "./service/compute"
+  workspace         = var.workspace
+  name_format       = format(var.name_format, local.name_format_compute)
+  max_expiry        = var.max_expiry
+  freshness_default = var.freshness_default
+  feature_flags     = var.feature_flags
+
+  google = local.base_module
+}
+<<<<<<< HEAD
+=======
+
+>>>>>>> 24c23d7 (feat: Compute - creation of compute content)

--- a/main.tf
+++ b/main.tf
@@ -117,6 +117,9 @@ resource "observe_dataset" "resource_asset_inventory_records" {
     input    = "events"
     pipeline = <<-EOF
       filter not is_null(resource)
+
+      make_col ttl: case(deleted, 1ns, true, ${var.max_expiry})
+
       pick_col 
         time,
         deleted,
@@ -127,7 +130,8 @@ resource "observe_dataset" "resource_asset_inventory_records" {
         discovery_name:string(resource.discovery_name),
         location:string(resource.location),
         parent:string(resource.parent),
-        version:string(resource.version)
+        version:string(resource.version),
+        ttl
     EOF
   }
 }
@@ -219,7 +223,9 @@ resource "observe_dataset" "audit_logs" {
       requestMetadata:object(protoPayload.requestMetadata),
       request:object(protoPayload.request),
       response:object(protoPayload.response),
-      serviceData:object(protoPayload.serviceData)
+      serviceData:object(protoPayload.serviceData),
+      resourceLabels,
+      resourceType
     EOF
   }
 }

--- a/service/cloudsql/logs.tf
+++ b/service/cloudsql/logs.tf
@@ -1,0 +1,46 @@
+resource "observe_dataset" "sql_logs" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Logs")
+  freshness = var.freshness_default
+
+  inputs = {
+    "logs" = var.google.logs.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resourceType = "cloudsql_database"
+
+      make_col 
+        database_id:string(resourceLabels.database_id),
+        project_id:string(resourceLabels.project_id),
+        region:string(resourceLabels.region)
+
+      pick_col 
+        timestamp,
+        receiveTimestamp,
+        logName,
+        severity,
+        textPayload,
+        protoPayload,
+        project_id,
+        region,
+        database_id
+    EOF
+  }
+}
+
+resource "observe_link" "sql_logs" {
+  workspace = var.workspace.oid
+  source    = observe_dataset.sql_logs.oid
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+
+  for_each = {
+    "Database" = {
+      target = observe_dataset.cloudsql.oid
+      fields = ["project_id", "region", "database_id"]
+    }
+  }
+}

--- a/service/cloudsql/main.tf
+++ b/service/cloudsql/main.tf
@@ -1,0 +1,62 @@
+
+locals {
+  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  # tflint-ignore: terraform_unused_declarations
+  enable_monitors = lookup(var.feature_flags, "monitors", true)
+}
+
+resource "observe_dataset" "cloudsql" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Instance")
+  freshness = var.freshness_default
+
+  inputs = {
+    "events" = var.google.resource_asset_inventory_records.oid
+  }
+
+  # https://cloud.google.com/sql/docs
+  stage {
+    input    = "events"
+    pipeline = <<-EOF
+      filter asset_type = "sqladmin.googleapis.com/Instance"
+      make_col
+        assetInventoryName:name,
+        name:string(data.name)
+      make_resource options(expiry:${var.max_expiry}),
+        name,
+        databaseVersion: string(data.databaseVersion),
+        label: strcat(string(data.databaseVersion),":",name),
+        databaseInstalledVersion: string(data.databaseInstalledVersion),
+        project_id: string(data.project),
+        region:  string(data.region),
+        database_id: strcat(string(data.project),":",name),
+        backendType:string(data.backendType),
+        createTime:string(data.createTime),
+        ipAddresses:string(data.ipAddresses),
+        gceZone:string(data.gceZone),
+        settings:string(data.settings),
+        primary_key(assetInventoryName),
+        valid_for(ttl)
+
+      add_key name
+      set_label label
+
+      add_key project_id, region, database_id
+    EOF
+  }
+}
+
+
+
+
+# resource "observe_board" "function" {
+#   for_each = length(observe_dataset.function_metrics) > 0 ? toset(["set", "singleton"]) : toset([])
+
+#   dataset = observe_dataset.function.oid
+#   name    = "Monitoring"
+#   json = templatefile("${path.module}/boards/monitoring.json", {
+#     dataset_cloudFunctionsFunctionMetrics = observe_dataset.function_metrics[0].oid
+#     dataset_cloudFunctionsFunction        = observe_dataset.function.oid
+#   })
+#   type = each.key
+# }

--- a/service/cloudsql/metrics.tf
+++ b/service/cloudsql/metrics.tf
@@ -1,0 +1,141 @@
+# cloudsql.googleapis.com/database/memory/usage
+
+
+# cloudsql.googleapis.com/database/memory/total_usage
+# cloudsql.googleapis.com/database/state
+# 
+# cloudsql.googleapis.com/database/disk/bytes_used
+# cloudsql.googleapis.com/database/disk/bytes_used_by_data_type
+# https://cloud.google.com/sql/docs/mysql/admin-api/metrics
+locals {
+  cloudsql_metrics = {
+    "cloudsql.googleapis.com/database/cpu/utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+        The CPU utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    "cloudsql.googleapis.com/database/memory/total_usage" = {
+      type        = "gauge"
+      description = <<-EOF
+        The total memory consumption in GiB. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    # cloudsql.googleapis.com/database/postgresql/num_backends
+    "cloudsql.googleapis.com/database/network/connections" = {
+      type        = "gauge"
+      description = <<-EOF
+        The number of active network connections. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    "cloudsql.googleapis.com/database/disk/write_ops_count" = {
+      type        = "gauge"
+      description = <<-EOF
+        The number of write operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    "cloudsql.googleapis.com/database/disk/read_ops_count" = {
+      type        = "gauge"
+      description = <<-EOF
+        The number of read operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    #logging.googleapis.com/log_entry_count - Log Entries by severity
+    "logging.googleapis.com/log_entry_count" = {
+      type        = "gauge"
+      description = <<-EOF
+        The disk utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    "cloudsql.googleapis.com/database/memory/utilization" = {
+      type        = "gauge"
+      description = <<-EOF
+        The memory utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+      EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+
+    # "cloudfunctions.googleapis.com/function/network_egress" = {
+    #   type        = "delta"
+    #   description = <<-EOF
+    #     Outgoing network traffic of function, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #   EOF
+    #   rollup      = "rate"
+    #   aggregate   = "sum"
+    # },
+    # "cloudfunctions.googleapis.com/function/user_memory_bytes" = {
+    #   type        = "delta"
+    #   description = <<-EOF
+    #     Distribution of maximum function's memory usage during execution, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 180 seconds.
+    #   EOF
+    #   rollup      = "avg"
+    #   aggregate   = "sum"
+    # },
+  }
+}
+
+resource "observe_dataset" "cloudsql_metrics" {
+  count = local.enable_metrics ? 1 : 0
+
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Metrics")
+  freshness = var.freshness_default
+
+  inputs = {
+    "metrics" = var.google.metrics.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resource_type = "cloudsql_database"
+
+      make_col 
+        database_id:string(resource_labels.database_id),
+        project_id:string(resource_labels.project_id),
+        region:string(resource_labels.region)
+
+      pick_col
+        start_time,
+        end_time,
+        metric_type,
+        metric_kind,
+        metric_labels,
+        value,
+        value_type,
+        project_id,
+        region,
+        database_id
+
+      interface "metric", metric:metric_type, value:value
+      ${join("\n\n", [for metric, options in local.cloudsql_metrics : indent(2, format("set_metric options(\n%s\n), %q", join(",\n", [for k, v in options : k == "interval" ? format("%s: %s", k, v) : format("%s: %q", k, v)]), metric))])}
+    EOF
+  }
+}
+
+resource "observe_link" "cloudsql_metrics" {
+  for_each = length(observe_dataset.cloudsql_metrics) > 0 ? {
+    "Cloud Function" = {
+      target = observe_dataset.cloudsql.oid
+      fields = ["project_id", "region", "database_id"]
+    }
+  } : {}
+
+  workspace = var.workspace.oid
+  source    = observe_dataset.cloudsql_metrics[0].oid
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+}

--- a/service/cloudsql/outputs.tf
+++ b/service/cloudsql/outputs.tf
@@ -1,0 +1,11 @@
+output "cloudsql" {
+  value = observe_dataset.cloudsql
+}
+
+output "cloudsql_logs" {
+  value = observe_dataset.sql_logs
+}
+
+output "cloudsql_metrics" {
+  value = local.enable_metrics ? observe_dataset.cloudsql_metrics[0] : null
+}

--- a/service/cloudsql/variables.tf
+++ b/service/cloudsql/variables.tf
@@ -1,0 +1,38 @@
+variable "workspace" {
+  type        = object({ oid = string })
+  description = "Workspace to apply module to."
+}
+
+variable "name_format" {
+  type        = string
+  description = "Format string to use for dataset names. Override to introduce a prefix or suffix."
+  default     = "%s"
+}
+
+variable "max_expiry" {
+  type        = string
+  description = "Maximum expiry time for resources."
+  default     = "4h"
+}
+
+variable "freshness_default" {
+  type        = string
+  description = "Default dataset freshness"
+  default     = "1m"
+}
+
+variable "feature_flags" {
+  type        = map(bool)
+  description = "Toggle features which are being rolled out or phased out."
+  default     = {}
+}
+
+variable "google" {
+  type = object({
+    resource_asset_inventory_records = object({ oid = string })
+    logs                             = object({ oid = string })
+    metrics                          = object({ oid = string })
+  })
+  description = "Google base module"
+}
+

--- a/service/cloudsql/versions.tf
+++ b/service/cloudsql/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+      version = "~> 0.6"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/service/compute/logs.tf
+++ b/service/compute/logs.tf
@@ -1,0 +1,43 @@
+resource "observe_dataset" "compute_logs" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Logs")
+  freshness = var.freshness_default
+
+  inputs = {
+    "audit_logs" = var.google.audit_logs.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resourceType = "gce_instance"
+
+      extract_regex string(resourceLabels.zone), /(?P<region>[a-z]+[-]+[a-z,0-9]+)/
+
+      pick_col 
+         timestamp,
+         request,
+         response,
+         requestMetadata,
+         authenticationInfo,
+         project_id: string(resourceLabels.project_id),
+         region,
+         instance_id: string(resourceLabels.instance_id),
+         zone: string(resourceLabels.zone)
+    EOF
+  }
+}
+
+resource "observe_link" "compute_logs" {
+  workspace = var.workspace.oid
+  source    = observe_dataset.compute_logs.oid
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+
+  for_each = {
+    "Compute" = {
+      target = observe_dataset.compute.oid
+      fields = ["project_id", "region", "instance_id"]
+    }
+  }
+}

--- a/service/compute/main.tf
+++ b/service/compute/main.tf
@@ -1,0 +1,257 @@
+
+locals {
+  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  # tflint-ignore: terraform_unused_declarations
+  enable_monitors = lookup(var.feature_flags, "monitors", true)
+}
+
+resource "observe_dataset" "compute" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Instance")
+  freshness = var.freshness_default
+
+  inputs = {
+    "events" = var.google.resource_asset_inventory_records.oid
+  }
+
+  # https://cloud.google.com/compute/docs
+  stage {
+    input    = "events"
+    pipeline = <<-EOF
+      filter  starts_with(asset_type, "compute.googleapis.com/Instance")
+
+      extract_regex name, /projects\/(?P<project_id>[^\/+]+)\/zones\/(?P<zone>[^\/+]+)\/instances\/(?P<instanceName>[^\/+]+)/
+      
+      extract_regex zone, /(?P<region>[a-z]+[-]+[a-z,0-9]+)/
+
+      make_col
+        assetInventoryName:name,
+        name:string(data.name),
+        instance_id:string(data.id)
+
+      make_resource options(expiry:${var.max_expiry}),
+        name,
+        cpuPlatform: string(data.cpuPlatform),
+        machineType: string(data.machineType),
+        project_id, 
+        region, 
+        instance_id,
+        primary_key(assetInventoryName),
+        valid_for(if(deleted, 1ns, ${var.max_expiry}))
+
+      add_key name
+      set_label name
+
+      add_key project_id, region, instance_id
+    EOF
+  }
+}
+
+<<<<<<< HEAD
+resource "observe_dataset" "compute_logs" {
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Compute Logs")
+  freshness = var.freshness_default
+
+  inputs = {
+    "audit_logs" = var.google.audit_logs.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resourceType = "gce_instance"
+
+      extract_regex string(resourceLabels.zone), /(?P<region>[a-z]+[-]+[a-z,0-9]+)/
+
+      pick_col 
+         timestamp,
+         request,
+         response,
+         requestMetadata,
+         authenticationInfo,
+         project_id: string(resourceLabels.project_id),
+         region,
+         instance_id: string(resourceLabels.instance_id),
+         zone: string(resourceLabels.zone)
+    EOF
+  }
+}
+
+# resource "observe_link" "sql_logs" {
+#   workspace = var.workspace.oid
+#   source    = observe_dataset.sql_logs.oid
+#   target    = each.value.target
+#   fields    = each.value.fields
+#   label     = each.key
+
+#   for_each = {
+#     "Database" = {
+#       target = observe_dataset.cloudsql.oid
+#       fields = ["project_id", "region", "database_id"]
+#     }
+#   }
+# }
+=======
+
+
+
+>>>>>>> 24c23d7 (feat: Compute - creation of compute content)
+
+
+# cloudsql.googleapis.com/database/memory/usage
+
+
+# cloudsql.googleapis.com/database/memory/total_usage
+# cloudsql.googleapis.com/database/state
+# 
+# cloudsql.googleapis.com/database/disk/bytes_used
+# cloudsql.googleapis.com/database/disk/bytes_used_by_data_type
+# https://cloud.google.com/sql/docs/mysql/admin-api/metrics
+<<<<<<< HEAD
+locals {
+  # cloudsql_metrics = {
+  #   "cloudsql.googleapis.com/database/cpu/utilization" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The CPU utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   "cloudsql.googleapis.com/database/memory/total_usage" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The total memory consumption in GiB. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   # cloudsql.googleapis.com/database/postgresql/num_backends
+  #   "cloudsql.googleapis.com/database/network/connections" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The number of active network connections. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   "cloudsql.googleapis.com/database/disk/write_ops_count" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The number of write operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   "cloudsql.googleapis.com/database/disk/read_ops_count" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The number of read operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   #logging.googleapis.com/log_entry_count - Log Entries by severity
+  #   "logging.googleapis.com/log_entry_count" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The disk utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+  #   "cloudsql.googleapis.com/database/memory/utilization" = {
+  #     type        = "gauge"
+  #     description = <<-EOF
+  #       The memory utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #     EOF
+  #     rollup      = "avg"
+  #     aggregate   = "sum"
+  #   },
+
+  # "cloudfunctions.googleapis.com/function/network_egress" = {
+  #   type        = "delta"
+  #   description = <<-EOF
+  #     Outgoing network traffic of function, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+  #   EOF
+  #   rollup      = "rate"
+  #   aggregate   = "sum"
+  # },
+  # "cloudfunctions.googleapis.com/function/user_memory_bytes" = {
+  #   type        = "delta"
+  #   description = <<-EOF
+  #     Distribution of maximum function's memory usage during execution, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 180 seconds.
+  #   EOF
+  #   rollup      = "avg"
+  #   aggregate   = "sum"
+  # },
+  # }
+}
+
+# resource "observe_dataset" "compute_metrics" {
+#   count = local.enable_metrics ? 1 : 0
+
+#   workspace = var.workspace.oid
+#   name      = format(var.name_format, "SQL Metrics")
+#   freshness = var.freshness_default
+
+#   inputs = {
+#     "metrics" = var.google.metrics.oid
+#   }
+
+#   stage {
+#     pipeline = <<-EOF
+#       filter resource_type = "cloudsql_database"
+
+#       make_col 
+#         database_id:string(resource_labels.database_id),
+#         project_id:string(resource_labels.project_id),
+#         region:string(resource_labels.region)
+
+#       pick_col
+#         start_time,
+#         end_time,
+#         metric_type,
+#         metric_kind,
+#         metric_labels,
+#         value,
+#         value_type,
+#         project_id,
+#         region,
+#         database_id
+
+#       interface "metric", metric:metric_type, value:value
+#       ${join("\n\n", [for metric, options in local.cloudsql_metrics : indent(2, format("set_metric options(\n%s\n), %q", join(",\n", [for k, v in options : k == "interval" ? format("%s: %s", k, v) : format("%s: %q", k, v)]), metric))])}
+#     EOF
+#   }
+# }
+
+# resource "observe_link" "compute_metrics" {
+#   for_each = length(observe_dataset.cloudsql_metrics) > 0 ? {
+#     "Cloud Function" = {
+#       target = observe_dataset.cloudsql.oid
+#       fields = ["project_id", "region", "database_id"]
+#     }
+#   } : {}
+
+#   workspace = var.workspace.oid
+#   source    = observe_dataset.cloudsql_metrics[0].oid
+#   target    = each.value.target
+#   fields    = each.value.fields
+#   label     = each.key
+# }
+=======
+>>>>>>> 24c23d7 (feat: Compute - creation of compute content)
+
+# resource "observe_board" "function" {
+#   for_each = length(observe_dataset.function_metrics) > 0 ? toset(["set", "singleton"]) : toset([])
+
+#   dataset = observe_dataset.function.oid
+#   name    = "Monitoring"
+#   json = templatefile("${path.module}/boards/monitoring.json", {
+#     dataset_cloudFunctionsFunctionMetrics = observe_dataset.function_metrics[0].oid
+#     dataset_cloudFunctionsFunction        = observe_dataset.function.oid
+#   })
+#   type = each.key
+# }
+

--- a/service/compute/metrics.tf
+++ b/service/compute/metrics.tf
@@ -1,0 +1,138 @@
+# https://cloud.google.com/monitoring/api/metrics_gcp#gcp-compute
+# https://registry.terraform.io/modules/terraform-google-modules/cloud-operations/google/latest/submodules/agent-policy
+# brew install coreutils
+# echo "alias python=/usr/bin/python3" >> ~/.zshrc
+
+locals {
+  compute_metrics = {
+    "compute.googleapis.com/instance/disk/max_read_bytes_count" = {
+      type        = "gauge"
+      description = <<-EOF
+          The CPU utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+        EOF
+      rollup      = "avg"
+      aggregate   = "sum"
+    },
+    #   "cloudsql.googleapis.com/database/memory/total_usage" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The total memory consumption in GiB. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+    #   # cloudsql.googleapis.com/database/postgresql/num_backends
+    #   "cloudsql.googleapis.com/database/network/connections" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The number of active network connections. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+    #   "cloudsql.googleapis.com/database/disk/write_ops_count" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The number of write operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+    #   "cloudsql.googleapis.com/database/disk/read_ops_count" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The number of read operations per second. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+    #   #logging.googleapis.com/log_entry_count - Log Entries by severity
+    #   "logging.googleapis.com/log_entry_count" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The disk utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+    #   "cloudsql.googleapis.com/database/memory/utilization" = {
+    #     type        = "gauge"
+    #     description = <<-EOF
+    #       The memory utilization percentage. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #     EOF
+    #     rollup      = "avg"
+    #     aggregate   = "sum"
+    #   },
+
+    # "cloudfunctions.googleapis.com/function/network_egress" = {
+    #   type        = "delta"
+    #   description = <<-EOF
+    #     Outgoing network traffic of function, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 240 seconds.
+    #   EOF
+    #   rollup      = "rate"
+    #   aggregate   = "sum"
+    # },
+    # "cloudfunctions.googleapis.com/function/user_memory_bytes" = {
+    #   type        = "delta"
+    #   description = <<-EOF
+    #     Distribution of maximum function's memory usage during execution, in bytes. Sampled every 60 seconds. After sampling, data is not visible for up to 180 seconds.
+    #   EOF
+    #   rollup      = "avg"
+    #   aggregate   = "sum"
+    # },
+  }
+}
+
+resource "observe_dataset" "compute_metrics" {
+  count = local.enable_metrics ? 1 : 0
+
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Metrics")
+  freshness = var.freshness_default
+
+  inputs = {
+    "metrics" = var.google.metrics.oid
+  }
+
+  stage {
+    pipeline = <<-EOF
+      filter resource_type = "gce_instance"
+
+ EOF
+  }
+}
+
+#  make_col 
+#     database_id:string(resource_labels.database_id),
+#     project_id:string(resource_labels.project_id),
+#     region:string(resource_labels.region)
+
+#   pick_col
+#     start_time,
+#     end_time,
+#     metric_type,
+#     metric_kind,
+#     metric_labels,
+#     value,
+#     value_type,
+#     project_id,
+#     region,
+#     database_id
+
+#   interface "metric", metric:metric_type, value:value
+#   ${join("\n\n", [for metric, options in local.cloudsql_metrics : indent(2, format("set_metric options(\n%s\n), %q", join(",\n", [for k, v in options : k == "interval" ? format("%s: %s", k, v) : format("%s: %q", k, v)]), metric))])}
+
+# resource "observe_link" "compute_metrics" {
+#   for_each = length(observe_dataset.cloudsql_metrics) > 0 ? {
+#     "Cloud Function" = {
+#       target = observe_dataset.cloudsql.oid
+#       fields = ["project_id", "region", "database_id"]
+#     }
+#   } : {}
+
+#   workspace = var.workspace.oid
+#   source    = observe_dataset.cloudsql_metrics[0].oid
+#   target    = each.value.target
+#   fields    = each.value.fields
+#   label     = each.key
+# }

--- a/service/compute/variables.tf
+++ b/service/compute/variables.tf
@@ -1,0 +1,39 @@
+variable "workspace" {
+  type        = object({ oid = string })
+  description = "Workspace to apply module to."
+}
+
+variable "name_format" {
+  type        = string
+  description = "Format string to use for dataset names. Override to introduce a prefix or suffix."
+  default     = "%s"
+}
+
+variable "max_expiry" {
+  type        = string
+  description = "Maximum expiry time for resources."
+  default     = "4h"
+}
+
+variable "freshness_default" {
+  type        = string
+  description = "Default dataset freshness"
+  default     = "1m"
+}
+
+variable "feature_flags" {
+  type        = map(bool)
+  description = "Toggle features which are being rolled out or phased out."
+  default     = {}
+}
+
+variable "google" {
+  type = object({
+    resource_asset_inventory_records = object({ oid = string })
+    logs                             = object({ oid = string })
+    metrics                          = object({ oid = string })
+    audit_logs                       = object({ oid = string })
+  })
+  description = "Google base module"
+}
+

--- a/service/compute/versions.tf
+++ b/service/compute/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+      version = "~> 0.6"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,19 @@ variable "enable_service_cloudfunctions" {
     Enable Cloud Functions service.
   EOF
 }
+
+variable "enable_service_cloudsql" {
+  type        = bool
+  default     = null
+  description = <<-EOF
+    Enable Cloud SQL service.
+  EOF
+}
+
+variable "enable_service_compute" {
+  type        = bool
+  default     = null
+  description = <<-EOF
+    Enable Compute service.
+  EOF
+}


### PR DESCRIPTION
## What does this PR do?

Adds Compute as optional service and creates datasets for compute logs, metrics and resources.

## Motivation

Build out of GCP content

## Limitations

Waiting for dashboard release to build out boards

## Testing

Created terraform or creating on demand compute UBUNTU 20_04/18_04 instances.
