### PR TITLE
ci: skip single-commit check for this repo

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       # you can opt out of ci-tests scheduled by adding a list of "jobs" ids for the 
       # tests that you want to skip, like so...
       # skip: '{"jobs": ["conventional-commits", "single-commit"]}'
-      skip: '{}'
+      skip: '{"jobs": ["single-commit"]}'
 
   pre-commits:
     uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit.yaml@main


### PR DESCRIPTION
## What does this PR do?

Skips the single-commit check for this repo. Why -- the owners of this repo prefer to take the squash-and-merge approach to merging commits, so as long as the PR title complies with conventional commits, a single-commit is not necessary. 