### PR TITLE
chore: add package syntax to name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "datastream" {
 variable "name_format" {
   type        = string
   description = "Format string to use for dataset names. Override to introduce a prefix or suffix."
-  default     = "GCP %s"
+  default     = "GCP/%s"
 }
 
 variable "max_expiry" {


### PR DESCRIPTION
## What does this PR do?

Adds package syntax to base name format

## Motivation

So when installed groups under package

## Testing

Standard
