### PR TITLE
fix: use lookaround_joins for load balancing resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module "google" {
 | <a name="module_cloudfunctions"></a> [cloudfunctions](#module\_cloudfunctions) | ./service/cloudfunctions | n/a |
 | <a name="module_cloudsql"></a> [cloudsql](#module\_cloudsql) | ./service/cloudsql | n/a |
 | <a name="module_compute"></a> [compute](#module\_compute) | ./service/compute | n/a |
+| <a name="module_load_balancing"></a> [load\_balancing](#module\_load\_balancing) | ./service/loadbalancing | n/a |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./service/storage | n/a |
 
 ## Resources

--- a/enable.tf
+++ b/enable.tf
@@ -95,16 +95,16 @@ module "storage" {
   google = local.base_module
 }
 
-# module "load_balancing" {
-#   count = local.enable_service_load_balancing ? 0 : 0
+module "load_balancing" {
+  count = local.enable_service_load_balancing ? 1 : 0
 
-#   source              = "./service/loadbalancing"
-#   workspace           = var.workspace
-#   name_format         = format(var.name_format, local.name_format_load_balancing)
-#   max_expiry          = var.max_expiry
-#   freshness_default   = var.freshness_default
-#   freshness_overrides = var.freshness_overrides
-#   feature_flags       = var.feature_flags
+  source              = "./service/loadbalancing"
+  workspace           = var.workspace
+  name_format         = format(var.name_format, local.name_format_load_balancing)
+  max_expiry          = var.max_expiry
+  freshness_default   = var.freshness_default
+  freshness_overrides = var.freshness_overrides
+  feature_flags       = var.feature_flags
 
-#   google = local.base_module
-# }
+  google = local.base_module
+}

--- a/tftests/all_services_all_opts/versions.tf
+++ b/tftests/all_services_all_opts/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     observe = {
       source  = "terraform.observeinc.com/observeinc/observe"
-      version = ">= 0.7.0"
+      version = ">= 0.9.2, <= 0.11.3"
     }
   }
   required_version = ">= 0.13.0"

--- a/tftests/all_services_def_opts/versions.tf
+++ b/tftests/all_services_def_opts/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     observe = {
       source  = "terraform.observeinc.com/observeinc/observe"
-      version = ">= 0.7.0"
+      version = ">= 0.9.2, <= 0.11.3"
     }
   }
   required_version = ">= 0.13.0"

--- a/tftests/default/versions.tf
+++ b/tftests/default/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     observe = {
       source  = "terraform.observeinc.com/observeinc/observe"
-      version = ">= 0.7.0"
+      version = ">= 0.9.2, <= 0.11.3"
     }
   }
   required_version = ">= 0.13.0"


### PR DESCRIPTION
## What does this PR do?

- Fixes the loadbalancing load balancer resource by forcing timestamps to line up right for `join` verbs (this works fine since these events are all from asset exports and their timestamp precision is not important)
- Adds back the loadbalancing service

## Motivation

Fixes Load Balancing service

## Limitations

Could theoretically run into problems with this approach if there are more than 1 gcp pubsub poller per observe account.

## Testing

Tested locally with expected results, and tftests passed locally too. 
