### PR TITLE
fix: setting enable_service_storage will no longer break app

### DIFF
--- a/asset_inventory.tf
+++ b/asset_inventory.tf
@@ -223,28 +223,39 @@ resource "observe_dataset" "iam_policy_asset_inventory_records" {
 }
 
 resource "observe_link" "resource_asset_inventory_resource" {
-  for_each = {
+  for_each = merge({
     "Projects" = {
       target = observe_dataset.projects_collection_enabled.oid
       fields = ["project_id"]
     }
-    "Compute" = {
-      target = one(module.compute[*].compute.oid)
-      fields = ["project_id"]
-    }
-    "CloudFunction" = {
-      target = one(module.cloudfunctions[*].function.oid)
-      fields = ["project_id:projectId"]
-    }
-    "Storage" = {
-      target = one(module.storage[*].storage.oid)
-      fields = ["project_id"]
-    }
-    "CloudSQL" = {
-      target = one(module.cloudsql[*].cloudsql.oid)
-      fields = ["project_id"]
-    }
-  }
+    },
+    var.enable_service_storage ? {
+      "Storage" = {
+        target = one(module.storage[*].storage.oid)
+        fields = ["project_id"]
+      }
+    } : {},
+    var.enable_service_compute ? {
+      "Compute" = {
+        target = one(module.compute[*].compute.oid)
+        fields = ["project_id"]
+      }
+    } : {},
+    var.enable_service_cloudsql ? {
+      "CloudSQL" = {
+        target = one(module.cloudsql[*].cloudsql.oid)
+        fields = ["project_id"]
+      }
+    } : {},
+    var.enable_service_cloudfunctions ? {
+      "CloudFunction" = {
+        target = one(module.cloudfunctions[*].function.oid)
+        fields = ["project_id:projectId"]
+      }
+    } : {},
+  )
+
+
 
   workspace = var.workspace.oid
   source    = observe_dataset.resources_asset_inventory.oid


### PR DESCRIPTION
## What does this PR do?

The storage link will not be created for the asset inventory if `enable_service_storage`.  Previously, the link would try to read a blank target if it was disabled which would break TF.

## Testing

Tested on my staging instance with flag enabled and disabled.