### PR TITLE
fix: add support for target pools and improve load balancer links

### DIFF
--- a/service/loadbalancing/loadBalancingDashboard.tf
+++ b/service/loadbalancing/loadBalancingDashboard.tf
@@ -1,10 +1,10 @@
 locals {
   workspace                        = var.workspace.oid
   dashboard_name                   = format(var.name_format, "Monitoring")
-  load_balancing_load_balancers    = observe_dataset.load_balancing_load_balancers.id
+  load_balancing_load_balancers    = observe_dataset.load_balancing_load_balancer.id
   load_balancing_metrics           = one(observe_dataset.load_balancing_metrics[*].id)
   load_balancing_config_audit_logs = observe_dataset.load_balancing_config_audit_logs.id
-  load_balancing_health_checks     = observe_dataset.load_balancing_health_checks.id
+  load_balancing_health_checks     = observe_dataset.load_balancing_health_check.id
 }
 # terraform import observe_dashboard.load_balancing_monitoring_old_tf 41146438
 resource "observe_dashboard" "load_balancing_monitoring" {

--- a/service/loadbalancing/logs.tf
+++ b/service/loadbalancing/logs.tf
@@ -156,28 +156,28 @@ resource "observe_link" "load_balancing_logs" {
 
   for_each = {
     "Load Balancer" = {
-      target = observe_dataset.load_balancing_load_balancers.oid
+      target = observe_dataset.load_balancing_load_balancer.oid
       fields = ["url_map_name:name"]
     },
-    "Backend Service" = {
-      target = observe_dataset.backend_services.oid
+    "Backend" = {
+      target = observe_dataset.backend.oid
       fields = ["backend_service_name:name"]
     },
     "Forwarding Rule" = {
-      target = observe_dataset.forwarding_rules.oid
+      target = observe_dataset.forwarding_rule.oid
       fields = ["forwarding_rule_name:frontend_name"]
     },
     "Target Proxy" = {
-      target = observe_dataset.target_proxies.oid
+      target = observe_dataset.target_proxy.oid
       fields = ["target_proxy_name:name"]
     }
   }
 }
 
-resource "observe_link" "healthcheck_logs_to_instance_groups" {
+resource "observe_link" "healthcheck_logs_to_instance_group" {
   workspace = var.workspace.oid
   source    = observe_dataset.health_check_logs.oid
-  target    = observe_dataset.instance_groups.oid
+  target    = observe_dataset.instance_group.oid
   fields    = ["instance_group_name:name"]
   label     = "Instance Group"
 }

--- a/service/loadbalancing/metrics.tf
+++ b/service/loadbalancing/metrics.tf
@@ -80,10 +80,10 @@ resource "observe_dataset" "load_balancing_metrics" {
 }
 
 
-resource "observe_link" "url_maps_metrics" {
+resource "observe_link" "url_map_metrics" {
   for_each = length(observe_dataset.load_balancing_metrics) > 0 ? {
     "Url Map" = {
-      target = observe_dataset.url_maps.oid
+      target = observe_dataset.url_map.oid
       fields = ["url_map_name:name"]
     }
   } : {}
@@ -96,10 +96,10 @@ resource "observe_link" "url_maps_metrics" {
 }
 
 
-resource "observe_link" "backend_services_metrics" {
+resource "observe_link" "backend_metrics" {
   for_each = length(observe_dataset.load_balancing_metrics) > 0 ? {
     "Backend Service" = {
-      target = observe_dataset.backend_services.oid
+      target = observe_dataset.backend.oid
       fields = ["backend_target_name:name"]
     }
   } : {}
@@ -114,7 +114,7 @@ resource "observe_link" "backend_services_metrics" {
 resource "observe_link" "forwarding_rules_metrics" {
   for_each = length(observe_dataset.load_balancing_metrics) > 0 ? {
     "Frontend Forwarding Rule" = {
-      target = observe_dataset.forwarding_rules.oid
+      target = observe_dataset.forwarding_rule.oid
       fields = ["forwarding_rule_name:frontend_name"]
     }
   } : {}
@@ -126,10 +126,10 @@ resource "observe_link" "forwarding_rules_metrics" {
   label     = each.key
 }
 
-resource "observe_link" "target_proxies_metrics" {
+resource "observe_link" "target_proxy_metrics" {
   for_each = length(observe_dataset.load_balancing_metrics) > 0 ? {
     "Target Proxy" = {
-      target = observe_dataset.target_proxies.oid
+      target = observe_dataset.target_proxy.oid
       fields = ["target_proxy_name:name"]
     }
   } : {}
@@ -144,7 +144,7 @@ resource "observe_link" "target_proxies_metrics" {
 resource "observe_link" "load_balancer_metrics" {
   for_each = length(observe_dataset.load_balancing_metrics) > 0 ? {
     "Load Balancer" = {
-      target = observe_dataset.load_balancing_load_balancers.oid
+      target = observe_dataset.load_balancing_load_balancer.oid
       fields = [
         "load_balancer_name:name",
         "forwarding_rule_name:frontEnd",

--- a/service/loadbalancing/outputs.tf
+++ b/service/loadbalancing/outputs.tf
@@ -1,9 +1,9 @@
 output "load_balancers_url_maps" {
-  value = observe_dataset.url_maps
+  value = observe_dataset.url_map
 }
 
 output "load_balancers" {
-  value = observe_dataset.load_balancing_load_balancers
+  value = observe_dataset.load_balancing_load_balancer
 }
 
 


### PR DESCRIPTION
## What does this PR do?

1. Adds support for target pool backends
2. Fixes filtering problems with Backend and TargetProxy resources
3. Fixes join problem with Load Balancers + Frontends
4. Makes resources singular instead of plural

## Limitations

We may want to add / modify more links in the future

## Testing

tftests pass locally, works much better now in my staging account than it did before (i was able to reproduce all the problems i saw in a customer account and this change fixed them)
