### PR TITLE
fix: set default dashboard on projects to the project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module "google" {
 | observe_dataset.resource_asset_inventory_records | resource |
 | observe_dataset.resources_asset_inventory | resource |
 | observe_dataset.string_metrics | resource |
+| observe_default_dashboard.default_project_dash | resource |
 
 ## Inputs
 

--- a/projects.tf
+++ b/projects.tf
@@ -60,6 +60,12 @@ resource "observe_dataset" "projects_collection_enabled" {
   }
 }
 
+# set default dashboard
+resource "observe_default_dashboard" "default_project_dash" {
+  dataset   = observe_dataset.projects_collection_enabled.oid
+  dashboard = resource.observe_dashboard.project_input.oid
+}
+
 # resource "observe_link" "project" {
 #   for_each = length(observe_dataset.projects_collection_enabled) > 0 ? {
 #     "AssetInventory" = {


### PR DESCRIPTION
## What does this PR do?

Sets the default dashboard for collection enabled projects to project monitoring dashboards

## Motivation

we don't want bigquery to be the default dashboard

## Testing

Tested in my staging account