### PR TITLE
fix: icon url

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,4 +2,4 @@ name: GCP
 description: Track all of your resources across GCP services such as Compute Engine, Cloud Storage, Cloud Functions, and more.
 defaultfolder: gcp
 defaultdatastream: GCP
-iconurl: https://assets.observeinc.com/icons/apps/terraform-observe-aws/aws-icon.png
+iconurl: https://assets.observeinc.com/icons/apps/terraform-observe-google/gcp-logo.png


### PR DESCRIPTION
## What does this PR do?

Updates GCP Icon for best quality, ensures it's self-hosted instead of remote host

## Testing

Tested in eng
