### PR TITLE
fix: swap source/target for some links

### DIFF
--- a/enable.tf
+++ b/enable.tf
@@ -204,7 +204,7 @@ module "gke" {
     compute_instance_group                  = one(module.compute[*].compute_instance_group)
     compute_instance                        = one(module.compute[*].compute)
     compute_metrics                         = one(module.compute[*].compute_metrics)
-    compute_instance_group_link_to_instance = one(module.compute[*].compute_instance_group_link_to_instance)
+    compute_instance_link_to_instance_group = one(module.compute[*].compute_instance_link_to_instance_group)
     compute_instance_link_to_disk           = one(module.compute[*].compute_instance_link_to_disk)
   })
 

--- a/service/compute/links.tf
+++ b/service/compute/links.tf
@@ -67,20 +67,13 @@ locals {
     }
 
     "ComputeInstanceToInstanceGroup" = {
+      source = observe_dataset.compute_instance.oid
       target = observe_dataset.instance_group.oid
       fields = ["instanceGroupAssetKey"]
-      source = observe_dataset.compute_instance.oid
       label  = "Compute Instances"
       create = true
     }
 
-    "InstanceGroupToComputeInstance" = {
-      source = observe_dataset.instance_group.oid
-      fields = ["instanceGroupAssetKey"]
-      target = observe_dataset.compute_instance.oid
-      label  = "Compute Instances"
-      create = true
-    }
   }
 }
 
@@ -150,8 +143,8 @@ resource "observe_preferred_path" "instance_groups_compute" {
   description = "Link to Compute Instances associated with current set of Instance Groups"
   source      = observe_dataset.instance_group.oid
   step {
-    link    = observe_link.compute["InstanceGroupToComputeInstance"].oid
-    reverse = false
+    link    = observe_link.compute["ComputeInstanceToInstanceGroup"].oid
+    reverse = true
   }
 }
 # tflint-ignore: terraform_unsupported_argument
@@ -163,8 +156,8 @@ resource "observe_preferred_path" "compute_instance_groups" {
   description = "Link to instance groups associated with current set of compute instances"
   source      = observe_dataset.compute_instance.oid
   step {
-    link    = observe_link.compute["InstanceGroupToComputeInstance"].oid
-    reverse = true
+    link    = observe_link.compute["ComputeInstanceToInstanceGroup"].oid
+    reverse = false
   }
 }
 
@@ -176,8 +169,8 @@ resource "observe_preferred_path" "instance_group_compute_disk" {
   source      = observe_dataset.instance_group.oid
 
   step {
-    link    = observe_link.compute["InstanceGroupToComputeInstance"].oid
-    reverse = false
+    link    = observe_link.compute["ComputeInstanceToInstanceGroup"].oid
+    reverse = true
   }
 
   step {

--- a/service/compute/outputs.tf
+++ b/service/compute/outputs.tf
@@ -18,8 +18,8 @@ output "compute_instance_group" {
   value = observe_dataset.instance_group
 }
 
-output "compute_instance_group_link_to_instance" {
-  value = observe_link.compute["InstanceGroupToComputeInstance"]
+output "compute_instance_link_to_instance_group" {
+  value = observe_link.compute["ComputeInstanceToInstanceGroup"]
 }
 
 output "compute_disk" {

--- a/service/gke/links.tf
+++ b/service/gke/links.tf
@@ -18,10 +18,10 @@ resource "observe_link" "gke" {
       label  = "Logs"
     }
 
-    "GKEClusterToInstanceGroup" = {
-      target = var.google.compute_instance_group.oid
+    "InstanceGroupToGKECluster" = {
+      source = var.google.compute_instance_group.oid
+      target = observe_dataset.gke_clusters.oid
       fields = ["gkeClusterAssetKey"]
-      source = observe_dataset.gke_clusters.oid
       label  = "Instance group"
     }
 
@@ -51,12 +51,12 @@ resource "observe_preferred_path" "gke_to_compute" {
   description = "Link to compute instances that are used as nodes in current set of GKE Clusters"
   source      = observe_dataset.gke_clusters.oid
   step {
-    link    = observe_link.gke["GKEClusterToInstanceGroup"].oid
-    reverse = false
+    link    = observe_link.gke["InstanceGroupToGKECluster"].oid
+    reverse = true
   }
   step {
-    link    = var.google.compute_instance_group_link_to_instance.oid
-    reverse = false
+    link    = var.google.compute_instance_link_to_instance_group.oid
+    reverse = true
   }
 }
 
@@ -66,12 +66,12 @@ resource "observe_preferred_path" "gke_to_disk" {
   description = "Link to compute disk instances that are used by nodes in current set of GKE Clusters"
   source      = observe_dataset.gke_clusters.oid
   step {
-    link    = observe_link.gke["GKEClusterToInstanceGroup"].oid
-    reverse = false
+    link    = observe_link.gke["InstanceGroupToGKECluster"].oid
+    reverse = true
   }
   step {
-    link    = var.google.compute_instance_group_link_to_instance.oid
-    reverse = false
+    link    = var.google.compute_instance_link_to_instance_group.oid
+    reverse = true
   }
   step {
     link    = var.google.compute_instance_link_to_disk.oid

--- a/service/gke/outputs.tf
+++ b/service/gke/outputs.tf
@@ -15,5 +15,5 @@ output "logs" {
 }
 
 output "instance_group_link" {
-  value = observe_link.gke["GKEClusterToInstanceGroup"]
+  value = observe_link.gke["InstanceGroupToGKECluster"]
 }

--- a/service/gke/variables.tf
+++ b/service/gke/variables.tf
@@ -42,7 +42,7 @@ variable "google" {
     compute_instance_group                  = object({ oid = string, id = string })
     compute_instance                        = object({ oid = string, id = string })
     compute_metrics                         = object({ oid = string, id = string })
-    compute_instance_group_link_to_instance = object({ oid = string, id = string })
+    compute_instance_link_to_instance_group = object({ oid = string, id = string })
     compute_instance_link_to_disk           = object({ oid = string, id = string })
   })
   description = "Google base module"


### PR DESCRIPTION
## What does this PR do?

The field for the target of link should be a primary key (uniquely identifying one resource).

This may lead to GraphLink paths that miss data if the Snowflake compiler does some optimizations in the future.

Testing:
I've tested the links and pasted output in https://github.com/observeinc/terraform-observe-google/pull/122