### PR TITLE
fix: gate preferred paths with feature flag

### DIFF
--- a/service/compute/links.tf
+++ b/service/compute/links.tf
@@ -1,6 +1,4 @@
 locals {
-  use_name_format_in_preferred_path = lookup(var.feature_flags, "use_name_format_in_preferred_path", false)
-
   links = {
     "ComputeInstanceToProjects" = {
       source = observe_dataset.compute_instance.oid
@@ -89,6 +87,7 @@ resource "observe_link" "compute" {
 
 
 resource "observe_preferred_path" "compute_disk" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Disk") : "Link to Disk"
@@ -101,6 +100,7 @@ resource "observe_preferred_path" "compute_disk" {
 }
 
 resource "observe_preferred_path" "disk_compute" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Compute Instances") : "Link to Compute Instances"
@@ -113,6 +113,7 @@ resource "observe_preferred_path" "disk_compute" {
 }
 
 resource "observe_preferred_path" "compute_log" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Logs") : "Link to Logs"
@@ -125,6 +126,7 @@ resource "observe_preferred_path" "compute_log" {
 }
 
 resource "observe_preferred_path" "compute_metrics" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Compute Instances ") : "Link to Compute Instances "
@@ -137,6 +139,7 @@ resource "observe_preferred_path" "compute_metrics" {
 }
 
 resource "observe_preferred_path" "instance_groups_compute" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Compute Instances  ") : "Link to Compute Instances  "
@@ -150,6 +153,7 @@ resource "observe_preferred_path" "instance_groups_compute" {
 # tflint-ignore: terraform_unsupported_argument
 
 resource "observe_preferred_path" "compute_instance_groups" {
+  count = local.enable_preferred_paths ? 1 : 0
   # folder = observe_folder.gcp.oid
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to compute instance group") : "Link to compute instance group"
@@ -162,6 +166,7 @@ resource "observe_preferred_path" "compute_instance_groups" {
 }
 
 resource "observe_preferred_path" "instance_group_compute_disk" {
+  count = local.enable_preferred_paths ? 1 : 0
 
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Disk ") : "Link to Disk "

--- a/service/compute/main.tf
+++ b/service/compute/main.tf
@@ -1,8 +1,13 @@
 
 locals {
+
   enable_metrics = lookup(var.feature_flags, "metrics", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
+
+  enable_preferred_paths = lookup(var.feature_flags, "preferred_paths", true)
+
+  use_name_format_in_preferred_path = lookup(var.feature_flags, "use_name_format_in_preferred_path", false)
 
   enable_both = lookup(var.feature_flags, "monitors", true) && lookup(var.feature_flags, "metrics", true)
 

--- a/service/gke/links.tf
+++ b/service/gke/links.tf
@@ -1,7 +1,3 @@
-locals {
-  use_name_format_in_preferred_path = lookup(var.feature_flags, "use_name_format_in_preferred_path", false)
-}
-
 resource "observe_link" "gke" {
   for_each = {
     "ClustersToProject" = {
@@ -35,6 +31,8 @@ resource "observe_link" "gke" {
 }
 
 resource "observe_preferred_path" "gke_to_logs" {
+  count = local.enable_preferred_paths ? 1 : 0
+
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Logs ") : "Link to Logs "
   description = "Link to compute instances that are used as nodes in current set of GKE Clusters"
@@ -46,6 +44,7 @@ resource "observe_preferred_path" "gke_to_logs" {
 }
 
 resource "observe_preferred_path" "gke_to_compute" {
+  count       = local.enable_preferred_paths ? 1 : 0
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to Compute  ") : "Link to Compute  "
   description = "Link to compute instances that are used as nodes in current set of GKE Clusters"
@@ -61,6 +60,7 @@ resource "observe_preferred_path" "gke_to_compute" {
 }
 
 resource "observe_preferred_path" "gke_to_disk" {
+  count       = local.enable_preferred_paths ? 1 : 0
   workspace   = var.workspace.oid
   name        = local.use_name_format_in_preferred_path == true ? format(var.name_format, "Link to compute disk") : "Link to compute disk"
   description = "Link to compute disk instances that are used by nodes in current set of GKE Clusters"

--- a/service/gke/main.tf
+++ b/service/gke/main.tf
@@ -2,6 +2,8 @@ locals {
   # enable_metrics = lookup(var.feature_flags, "metrics", true)
   # tflint-ignore: terraform_unused_declarations
   # enable_monitors = lookup(var.feature_flags, "monitors", true)
+  enable_preferred_paths            = lookup(var.feature_flags, "preferred_paths", true)
+  use_name_format_in_preferred_path = lookup(var.feature_flags, "use_name_format_in_preferred_path", false)
 
   freshness = merge({}, var.freshness_overrides)
   /*

--- a/tftests/all_services_all_opts/main.tf
+++ b/tftests/all_services_all_opts/main.tf
@@ -28,8 +28,4 @@ module "all_services_all_opts" {
   feature_flags = {
     "use_name_format_in_preferred_path" = true
   }
-  # feature_flags = {
-  #   metrics  = false
-  #   monitors = false
-  # }
 }


### PR DESCRIPTION
## What does this PR do?

Disable preferred paths for now due to CI errors.

## Motivation

We get a lot of CI errors associated to invalid preferred paths. The fact these failures are flaky may indicate there is some racy behavior in the API.