### PR TITLE
feat: default redis metric collection

### DIFF
--- a/sources/monitoring/variables.tf
+++ b/sources/monitoring/variables.tf
@@ -65,7 +65,7 @@ variable "include_metric_type_prefixes" {
     "bigquery.googleapis.com/",
     "loadbalancing.googleapis.com",
     "kubernetes.io/",
-    "redis.googleapis.com"
+    "redis.googleapis.com/",
   ]
   description = <<-EOF
     Metrics with these Metric Types with these prefixes will be fetched.


### PR DESCRIPTION
## What does this PR do?

adds redis metrics endpoint to default value of include_metric_type_prefixes variable 

## Motivation

redis app

## Testing

tf tests
