### PR TITLE
fix: remove nulls from defaultValue in dashboards

### DIFF
--- a/dashboard_home.OLD
+++ b/dashboard_home.OLD
@@ -876,17 +876,9 @@ resource "observe_dashboard" "app_home" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
             datasetId   = "${local.projects_collection_enabled}"
-            datasetPath = null
-            stageId     = null
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-z5n5j9ss"
         name = "projects"

--- a/dashboard_home.tf
+++ b/dashboard_home.tf
@@ -868,17 +868,9 @@ resource "observe_dashboard" "app_home" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.projects_collection_enabled}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.projects_collection_enabled}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-z5n5j9ss"
         name = "projects"
@@ -890,13 +882,7 @@ resource "observe_dashboard" "app_home" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = ""
+          string = ""
         }
         id   = "service"
         name = "Service"
@@ -908,13 +894,7 @@ resource "observe_dashboard" "app_home" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = ""
+          string = ""
         }
         id   = "metricNamespace"
         name = "Metric Namespace"

--- a/dashboard_projects.tf
+++ b/dashboard_projects.tf
@@ -78,17 +78,9 @@ resource "observe_dashboard" "project_input" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.projects_collection_enabled}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.projects_collection_enabled}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-nsjl7kcg"
         name = "projects"

--- a/dashboard_resources.tf
+++ b/dashboard_resources.tf
@@ -79,17 +79,9 @@ resource "observe_dashboard" "resource_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.resources_asset_inventory}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.resources_asset_inventory}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-r2120qwo"
         name = "resources"

--- a/dashboard_tco.tf
+++ b/dashboard_tco.tf
@@ -206,13 +206,7 @@ resource "observe_dashboard" "total_cost_of_ownership" {
     [
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "full_export_v6"
+          string = "full_export_v6"
         }
         id   = "queryID"
         name = "Query ID"
@@ -224,13 +218,7 @@ resource "observe_dashboard" "total_cost_of_ownership" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "content-testpproj-stage-1"
+          string = "content-testpproj-stage-1"
         }
         id   = "projectID"
         name = "Project ID"
@@ -242,13 +230,7 @@ resource "observe_dashboard" "total_cost_of_ownership" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = ""
+          string = ""
         }
         id   = "serviceID"
         name = "Service"

--- a/service/bigquery/dashboard-dataset.tf
+++ b/service/bigquery/dashboard-dataset.tf
@@ -206,17 +206,9 @@ resource "observe_dashboard" "bigquery_dataset" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.bigquery_dataset}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.bigquery_dataset}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "dataset"
         name = "dataset"

--- a/service/bigquery/dashboard-project-rlp.tf
+++ b/service/bigquery/dashboard-project-rlp.tf
@@ -202,17 +202,9 @@ resource "observe_dashboard" "bigquery_project" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.projects_collection_enabled}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.projects_collection_enabled}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "project"
         name = "project"

--- a/service/bigquery/dashboard-project-singleton.tf
+++ b/service/bigquery/dashboard-project-singleton.tf
@@ -310,13 +310,7 @@ resource "observe_dashboard" "bigquery_project_overview" {
     [
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "query"
+          string = "query"
         }
         id   = "job_type"
         name = "job_type"
@@ -328,13 +322,7 @@ resource "observe_dashboard" "bigquery_project_overview" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "batch"
+          string = "batch"
         }
         id   = "priority"
         name = "priority"
@@ -346,13 +334,7 @@ resource "observe_dashboard" "bigquery_project_overview" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "running"
+          string = "running"
         }
         id   = "state"
         name = "state"

--- a/service/bigquery/dashboard-table.tf
+++ b/service/bigquery/dashboard-table.tf
@@ -108,17 +108,9 @@ resource "observe_dashboard" "bigquery_tables_manual" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "41252651"
-            datasetPath = null
-            stageId     = null
+            datasetId = "41252651"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-w81f71mb"
         name = "BigQuery Table"

--- a/service/cloudfunctions/cloudfunctionsDashboard.tf
+++ b/service/cloudfunctions/cloudfunctionsDashboard.tf
@@ -323,17 +323,9 @@ locals {
       [
         {
           defaultValue = {
-            array = null
-            bool  = null
             datasetref = {
-              datasetId   = "${local.cloud_functions_instances}"
-              datasetPath = null
-              stageId     = null
+              datasetId = "${local.cloud_functions_instances}"
             }
-            float64 = null
-            int64   = null
-            link    = null
-            string  = null
           }
           id   = "cloudFunctions"
           name = "cloudFunctions"

--- a/service/cloudsql/dashboard_monitoring.tf
+++ b/service/cloudsql/dashboard_monitoring.tf
@@ -500,17 +500,9 @@ resource "observe_dashboard" "cloud_sql_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.cloud_sql_instance}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.cloud_sql_instance}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "dbResource"
         name = "Cloud SQL Instance"

--- a/service/cloudsql/dashboard_singleton.tf
+++ b/service/cloudsql/dashboard_singleton.tf
@@ -419,45 +419,30 @@ resource "observe_dashboard" "cloud_sql_instance" {
     [
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
           link = {
             datasetId = "${local.cloud_sql_instance}"
             primaryKeyValue = [
               {
                 name = "assetInventoryName"
                 value = {
-                  bool    = null
-                  float64 = null
-                  int64   = null
-                  string  = "//cloudsql.googleapis.com/projects/terraflood-345116/instances/con-gha-main-g1-763-instance-tapir"
+                  string = "//cloudsql.googleapis.com/projects/terraflood-345116/instances/con-gha-main-g1-763-instance-tapir"
                 }
               },
               {
                 name = "database_id"
                 value = {
-                  bool    = null
-                  float64 = null
-                  int64   = null
-                  string  = "terraflood-345116:con-gha-main-g1-763-instance-tapir"
+                  string = "terraflood-345116:con-gha-main-g1-763-instance-tapir"
                 }
               },
               {
                 name = "name"
                 value = {
-                  bool    = null
-                  float64 = null
-                  int64   = null
-                  string  = "con-gha-main-g1-763-instance-tapir"
+                  string = "con-gha-main-g1-763-instance-tapir"
                 }
               },
             ]
             storedLabel = "con-gha-main-g1-763-instance-tapir"
           }
-          string = null
         }
         id   = "database"
         name = "Database"

--- a/service/compute/db_compute_monitoring.tf
+++ b/service/compute/db_compute_monitoring.tf
@@ -467,17 +467,9 @@ resource "observe_dashboard" "compute_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.compute_instance}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.compute_instance}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "computeID"
         name = "Compute Instance"

--- a/service/compute/db_disk_monitoring.tf
+++ b/service/compute/db_disk_monitoring.tf
@@ -253,17 +253,9 @@ resource "observe_dashboard" "disk_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.compute_disk}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.compute_disk}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-isvd5249"
         name = "disk"

--- a/service/gke/dashboard_gke_monitoring.tf
+++ b/service/gke/dashboard_gke_monitoring.tf
@@ -288,17 +288,9 @@ resource "observe_dashboard" "gke_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.gke_cluster}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.gke_cluster}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-21mm2wi0"
         name = "gkeCluster"

--- a/service/loadbalancing/loadBalancingDashboard.tf
+++ b/service/loadbalancing/loadBalancingDashboard.tf
@@ -779,17 +779,9 @@ resource "observe_dashboard" "load_balancing_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.load_balancing_load_balancers}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.load_balancing_load_balancers}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "loadBalancer"
         name = "Load Balancer"
@@ -801,13 +793,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "total_latencies"
+          string = "total_latencies"
         }
         id   = "latencyType"
         name = "Latency Type"
@@ -819,13 +805,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "avg"
+          string = "avg"
         }
         id   = "percentile"
         name = "Percentile"
@@ -837,13 +817,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "open_connections"
+          string = "open_connections"
         }
         id   = "connectionsType"
         name = "Connections Type"
@@ -855,13 +829,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = ""
+          string = ""
         }
         id   = "responseCode"
         name = "Response Code"
@@ -873,13 +841,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "avg"
+          string = "avg"
         }
         id   = "percentileL4"
         name = "Percentile"

--- a/service/pubsub/dashboard_service_monitor.tf
+++ b/service/pubsub/dashboard_service_monitor.tf
@@ -204,17 +204,9 @@ resource "observe_dashboard" "pubsub_pubsub_service_input2" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.pubsub_service}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.pubsub_service}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-ghoggkda"
         name = "service"

--- a/service/pubsub/dashboard_subscription_monitor.tf
+++ b/service/pubsub/dashboard_subscription_monitor.tf
@@ -150,17 +150,9 @@ resource "observe_dashboard" "pubsub_subscription_input" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.pubsub_subscriptions}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.pubsub_subscriptions}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-r4djwcuh"
         name = "subscriptions"

--- a/service/pubsub/dashboard_topic_monitor.tf
+++ b/service/pubsub/dashboard_topic_monitor.tf
@@ -171,17 +171,9 @@ resource "observe_dashboard" "pubsub_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.pubsub_topics}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.pubsub_topics}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "input-parameter-j9o4mgmh"
         name = "pubsubTopic"

--- a/service/storage/storageDashboard.tf
+++ b/service/storage/storageDashboard.tf
@@ -730,17 +730,9 @@ resource "observe_dashboard" "storage_monitoring" {
     [
       {
         defaultValue = {
-          array = null
-          bool  = null
           datasetref = {
-            datasetId   = "${local.storage_buckets}"
-            datasetPath = null
-            stageId     = null
+            datasetId = "${local.storage_buckets}"
           }
-          float64 = null
-          int64   = null
-          link    = null
-          string  = null
         }
         id   = "bucket"
         name = "Bucket"
@@ -752,13 +744,7 @@ resource "observe_dashboard" "storage_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "all"
+          string = "all"
         }
         id   = "responseCode"
         name = "Response Code"
@@ -770,13 +756,7 @@ resource "observe_dashboard" "storage_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "all"
+          string = "all"
         }
         id   = "method"
         name = "Method"
@@ -788,13 +768,7 @@ resource "observe_dashboard" "storage_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "authz_acl_based_object_access_count"
+          string = "authz_acl_based_object_access_count"
         }
         id   = "aclMetric"
         name = "ACL Metric"
@@ -806,13 +780,7 @@ resource "observe_dashboard" "storage_monitoring" {
       },
       {
         defaultValue = {
-          array      = null
-          bool       = null
-          datasetref = null
-          float64    = null
-          int64      = null
-          link       = null
-          string     = "Buckets without lifecycle rules"
+          string = "Buckets without lifecycle rules"
         }
         id   = "config"
         name = "Configuration Selection"


### PR DESCRIPTION
## What does this PR do?

Removes nulls from the `defaultValue` of dashboard parameters. These were erroneously introduced in previous provider versions and fixed in https://gerrit.observeinc.com/c/terraform-provider-observe/+/29413. 

## Motivation

Fix a perpetual diff.

## Testing

Tests were failing before on their idempotency check and should now pass