### PR TITLE
fix: cloudsql metrics

### DIFF
--- a/service/README_serviceUtilities.md
+++ b/service/README_serviceUtilities.md
@@ -12,6 +12,8 @@ This fetches data from gcp api and creates a json file to be read by next functi
 ./serviceUtilities.py fetch_metric_descriptors -o bigquery/bigquerymetrics.json -m "bigquery.googleapis.com"
 
 ./serviceUtilities.py fetch_metric_descriptors -o cloudfunctions/cloudfunctionmetrics.json -m "cloudfunctions.googleapis.com"
+
+./serviceUtilities.py fetch_metric_descriptors -o cloudsql/cloudsqlmetrics.json -m "cloudsql.googleapis.com"
 ```
 
 This reads json file and creates local_metricdescriptors.tf file with local variable defined that can be read in metrics dataset definition.
@@ -22,6 +24,8 @@ This reads json file and creates local_metricdescriptors.tf file with local vari
 ./serviceUtilities.py create_terraform -i bigquery/bigquerymetrics.json -t bigquery/local_metricdescriptors.tf 
 
 ./serviceUtilities.py create_terraform -i cloudfunctions/cloudfunctionmetrics.json -t cloudfunctions/local_metricdescriptors.tf 
+
+./serviceUtilities.py create_terraform -i cloudsql/cloudsqlmetrics.json -t cloudsql/local_metricdescriptors.tf 
 ```
 
 ## Changing metric definitions

--- a/service/cloudsql/local_metricdescriptors.tf
+++ b/service/cloudsql/local_metricdescriptors.tf
@@ -17,7 +17,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/active_directory/domain_reachable"
     label              = "Active Directory domain reachable"
     unit               = ""
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "BOOL"
     dataBase           = "ALL"
   }
@@ -33,7 +33,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/active_directory/instance_available"
     label              = "Windows Authentication available"
     unit               = ""
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "BOOL"
     dataBase           = "ALL"
   }
@@ -49,7 +49,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/auto_failover_request_count"
     label              = "Auto-failover Requests"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -65,7 +65,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/available_for_failover"
     label              = "Available for failover"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -81,7 +81,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/cpu/reserved_cores"
     label              = "CPU reserved cores"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -97,7 +97,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/cpu/usage_time"
     label              = "CPU usage"
     unit               = "s{CPU}"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -113,7 +113,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/cpu/utilization"
     label              = "CPU utilization"
     unit               = "10^2.%"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -129,7 +129,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/bytes_used"
     label              = "Bytes used"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -145,7 +145,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/bytes_used_by_data_type"
     label              = "Bytes used"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -161,7 +161,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/quota"
     label              = "Disk quota"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -177,7 +177,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/read_ops_count"
     label              = "Disk read IO"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -193,7 +193,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/utilization"
     label              = "Disk utilization"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -209,7 +209,7 @@ locals { metrics_definitions = {
     google_metric_path = "cloudsql.googleapis.com/database/disk/write_ops_count"
     label              = "Disk write IO"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -236,7 +236,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/instance_state"
     label              = "Instance state"
     unit               = ""
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "BOOL"
     dataBase           = "ALL"
   }
@@ -252,7 +252,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/memory/quota"
     label              = "Memory quota"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -268,7 +268,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/memory/total_usage"
     label              = "Total memory usage"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -284,7 +284,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/memory/usage"
     label              = "Memory usage"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -300,7 +300,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/memory/utilization"
     label              = "Memory utilization"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -316,7 +316,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_dirty"
     label              = "InnoDB dirty pages"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -332,7 +332,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_free"
     label              = "InnoDB free pages"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -348,7 +348,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_buffer_pool_pages_total"
     label              = "InnoDB total pages"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -364,7 +364,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_data_fsyncs"
     label              = "InnoDB fsync calls"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -380,7 +380,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_os_log_fsyncs"
     label              = "InnoDB log fsync calls"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -396,7 +396,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_pages_read"
     label              = "InnoDB pages read"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -412,7 +412,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/innodb_pages_written"
     label              = "InnoDB pages written"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -428,7 +428,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/queries"
     label              = "Queries"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -444,7 +444,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/questions"
     label              = "Questions"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -460,11 +460,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/received_bytes_count"
     label              = "Network bytes received by MySQL"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
-  available_for_failover = {
+  replication_available_for_failover = {
     type               = "gauge"
     description        = <<-EOF
                     This is greater than 0 if the failover operation is available on the master instance.master. The metric is deprecated.  Please use cloudsql.googleapis.com/database/available_for_failover instead
@@ -472,15 +472,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "BAD_VAL-5"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/available_for_failover"
     label              = "Available for failover Deprecated"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
-  last_io_errno = {
+  replication_last_io_errno = {
     type               = "gauge"
     description        = <<-EOF
                     The error number of the most recent error that caused the I/O thread to stop.
@@ -488,15 +488,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/last_io_errno"
     label              = "Last I/O thread error number."
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
-  last_sql_errno = {
+  replication_last_sql_errno = {
     type               = "gauge"
     description        = <<-EOF
                     The error number of the most recent error that caused the SQL thread to stop.
@@ -504,15 +504,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/last_sql_errno"
     label              = "Last SQL thread error number."
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
-  seconds_behind_master = {
+  replication_seconds_behind_master = {
     type               = "gauge"
     description        = <<-EOF
                     Number of seconds the read replica is behind its primary approximation.
@@ -520,15 +520,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/seconds_behind_master"
     label              = "Replication lag"
     unit               = "s"
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
-  slave_io_running = {
+  replication_slave_io_running = {
     type               = "gauge"
     description        = <<-EOF
                     Indicates whether the I/O thread for reading the primary's binary log is running. Possible values are Yes, No and Connecting.
@@ -536,15 +536,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/slave_io_running"
     label              = "Slave I/O thread running"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "STRING"
     dataBase           = "mysql"
   }
-  slave_io_running_state = {
+  replication_slave_io_running_state = {
     type               = "gauge"
     description        = <<-EOF
                     Indicates whether the I/O thread for reading the primary's binary log is running. Possible values are Yes, No and Connecting, and the values are exposed through the 'state' field.
@@ -552,15 +552,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/slave_io_running_state"
     label              = "Slave I/O thread running state"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "BOOL"
     dataBase           = "mysql"
   }
-  slave_sql_running = {
+  replication_slave_sql_running = {
     type               = "gauge"
     description        = <<-EOF
                     Indicates whether the SQL thread for executing events in the relay log is running.
@@ -568,15 +568,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/slave_sql_running"
     label              = "Slave SQL thread running"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "STRING"
     dataBase           = "mysql"
   }
-  slave_sql_running_state = {
+  replication_slave_sql_running_state = {
     type               = "gauge"
     description        = <<-EOF
                     Indicates whether the SQL thread for executing events in the relay log is running. Possible values are Yes / No, and the values are exposed through the 'state' field.
@@ -584,11 +584,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/mysql/replication/slave_sql_running_state"
     label              = "Slave SQL thread running state"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "mysql"
     valuetype          = "BOOL"
     dataBase           = "mysql"
   }
@@ -604,7 +604,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/mysql/sent_bytes_count"
     label              = "Network bytes sent by MySQL"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "mysql"
     valuetype          = "INT64"
     dataBase           = "mysql"
   }
@@ -620,7 +620,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/network/connections"
     label              = "Cloud SQL Connections"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -636,7 +636,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/network/received_bytes_count"
     label              = "Received bytes"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -652,7 +652,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/network/sent_bytes_count"
     label              = "Sent bytes"
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -668,7 +668,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/blocks_read_count"
     label              = "Number of disk blocks read."
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -684,11 +684,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/deadlock_count"
     label              = "Deadlocks count"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
-  initial_sync_complete = {
+  external_sync_initial_sync_complete = {
     type               = "gauge"
     description        = <<-EOF
                     Whether all databases on the Postgres External Server ES replica have completed the initial sync and are replicating changes from the source.
@@ -696,15 +696,15 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "ALPHA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "external_sync"
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/external_sync/initial_sync_complete"
     label              = "Initial sync complete"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "BOOL"
     dataBase           = "postgresql"
   }
-  max_replica_byte_lag = {
+  external_sync_max_replica_byte_lag = {
     type               = "gauge"
     description        = <<-EOF
                     Replication lag in bytes for Postgres External Server ES replicas. Aggregated across all DBs on the replica.
@@ -712,11 +712,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "ALPHA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "external_sync"
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/external_sync/max_replica_byte_lag"
     label              = "Max lag bytes"
     unit               = "By"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -732,7 +732,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/execution_time"
     label              = "Execution time"
     unit               = "us{CPU}"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -748,7 +748,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/io_time"
     label              = "IO time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -764,7 +764,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/latencies"
     label              = "Latency"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "DISTRIBUTION"
     dataBase           = "postgresql"
   }
@@ -780,7 +780,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/lock_time"
     label              = "Aggregated lock time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -796,7 +796,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/row_count"
     label              = "Affected rows"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -812,7 +812,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/aggregate/shared_blk_access_count"
     label              = "Shared blocks cache access."
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -828,7 +828,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/execution_time"
     label              = "Per query execution times"
     unit               = "us{CPU}"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -844,7 +844,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/io_time"
     label              = "Per query IO time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -860,7 +860,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/latencies"
     label              = "Per query latency"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "DISTRIBUTION"
     dataBase           = "postgresql"
   }
@@ -876,7 +876,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time"
     label              = "Per query lock time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -892,7 +892,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/row_count"
     label              = "Per query affected rows"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -908,7 +908,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/perquery/shared_blk_access_count"
     label              = "Per query Shared blocks cache access"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -924,7 +924,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/execution_time"
     label              = "Per tag execution time"
     unit               = "us{CPU}"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -940,7 +940,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/io_time"
     label              = "Per tag IO time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -956,7 +956,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/latencies"
     label              = "Per tag latency"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "DISTRIBUTION"
     dataBase           = "postgresql"
   }
@@ -972,7 +972,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/lock_time"
     label              = "Per tag lock time"
     unit               = "us"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -988,7 +988,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/row_count"
     label              = "Per tag affected rows"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1004,7 +1004,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/insights/pertag/shared_blk_access_count"
     label              = "Per tag shared blocks cache accessed"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1020,7 +1020,23 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/num_backends"
     label              = "PostgreSQL Connections"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
+    valuetype          = "INT64"
+    dataBase           = "postgresql"
+  }
+  postgresql_num_backends_by_application = {
+    type               = "gauge"
+    description        = <<-EOF
+                    Number of connections to the Cloud SQL PostgreSQL instance, grouped by applications.
+                EOF
+    launchStage        = "GA"
+    rollup             = "avg"
+    aggregate          = "sum"
+    metricCategory     = "postgresql"
+    google_metric_path = "cloudsql.googleapis.com/database/postgresql/num_backends_by_application"
+    label              = "PostgreSQL connections by application"
+    unit               = "1"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1036,11 +1052,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/num_backends_by_state"
     label              = "PostgreSQL Connections by State"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
-  replica_byte_lag = {
+  replication_replica_byte_lag = {
     type               = "gauge"
     description        = <<-EOF
                     Replication lag in bytes. Reported from the master per replica.
@@ -1048,11 +1064,43 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "replication"
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/replication/replica_byte_lag"
     label              = "Lag bytes"
     unit               = "By"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
+    valuetype          = "INT64"
+    dataBase           = "postgresql"
+  }
+  postgresql_temp_bytes_written_count = {
+    type               = "delta"
+    description        = <<-EOF
+                    Total amount of data in bytes written to temporary files by the queries per database.
+                EOF
+    launchStage        = "GA"
+    rollup             = "avg"
+    aggregate          = "sum"
+    metricCategory     = "postgresql"
+    google_metric_path = "cloudsql.googleapis.com/database/postgresql/temp_bytes_written_count"
+    label              = "Data in bytes written to temporary"
+    unit               = "1"
+    metricBin          = "postgresql"
+    valuetype          = "INT64"
+    dataBase           = "postgresql"
+  }
+  postgresql_temp_files_written_count = {
+    type               = "delta"
+    description        = <<-EOF
+                    Total number of temporary files used for writing data while performing algorithms such as join and sort.
+                EOF
+    launchStage        = "GA"
+    rollup             = "avg"
+    aggregate          = "sum"
+    metricCategory     = "postgresql"
+    google_metric_path = "cloudsql.googleapis.com/database/postgresql/temp_files_written_count"
+    label              = "Temporary files used for writing data"
+    unit               = "1"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1068,7 +1116,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/transaction_count"
     label              = "Number of transactions"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1084,7 +1132,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/transaction_id_count"
     label              = "Transaction ID count"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1100,7 +1148,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/transaction_id_utilization"
     label              = "Transaction ID utilization"
     unit               = "10^2.%"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "DOUBLE"
     dataBase           = "postgresql"
   }
@@ -1116,7 +1164,23 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/tuple_size"
     label              = "Number of tuples rows in the database."
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
+    valuetype          = "INT64"
+    dataBase           = "postgresql"
+  }
+  postgresql_tuples_fetched_count = {
+    type               = "delta"
+    description        = <<-EOF
+                    Total number of rows fetched as a result of queries per database in the PostgreSQL instance.
+                EOF
+    launchStage        = "GA"
+    rollup             = "avg"
+    aggregate          = "sum"
+    metricCategory     = "postgresql"
+    google_metric_path = "cloudsql.googleapis.com/database/postgresql/tuples_fetched_count"
+    label              = "Number of tuples fetched"
+    unit               = "1"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1132,11 +1196,27 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/tuples_processed_count"
     label              = "Number of rows processed"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
-  oldest_transaction_age = {
+  postgresql_tuples_returned_count = {
+    type               = "delta"
+    description        = <<-EOF
+                    Total number of rows scanned while processing the queries per database in the PostgreSQL instance.
+                EOF
+    launchStage        = "GA"
+    rollup             = "avg"
+    aggregate          = "sum"
+    metricCategory     = "postgresql"
+    google_metric_path = "cloudsql.googleapis.com/database/postgresql/tuples_returned_count"
+    label              = "Number of tuples returned"
+    unit               = "1"
+    metricBin          = "postgresql"
+    valuetype          = "INT64"
+    dataBase           = "postgresql"
+  }
+  vacuum_oldest_transaction_age = {
     type               = "gauge"
     description        = <<-EOF
                     Age of the oldest transaction yet to be vacuumed in the Cloud SQL PostgreSQL instance, measured in number of transactions that have happened since the oldest transaction.
@@ -1144,11 +1224,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "GA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "vacuum"
     google_metric_path = "cloudsql.googleapis.com/database/postgresql/vacuum/oldest_transaction_age"
     label              = "Oldest transaction age"
     unit               = "1"
-    metricBin          = "['']"
+    metricBin          = "postgresql"
     valuetype          = "INT64"
     dataBase           = "postgresql"
   }
@@ -1164,7 +1244,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/replication/log_archive_failure_count"
     label              = "Number of log archival failures."
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -1180,7 +1260,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/replication/log_archive_success_count"
     label              = "Number of log archival successes."
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -1196,7 +1276,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/replication/network_lag"
     label              = "Network lag"
     unit               = "s"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -1212,7 +1292,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/replication/replica_lag"
     label              = "Replication lag"
     unit               = "s"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "DOUBLE"
     dataBase           = "ALL"
   }
@@ -1228,7 +1308,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/replication/state"
     label              = "Replication state"
     unit               = ""
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "BOOL"
     dataBase           = "ALL"
   }
@@ -1244,7 +1324,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/sqlserver/audits_size"
     label              = "Size of stored audit files."
     unit               = "By"
-    metricBin          = "['database']"
+    metricBin          = "sqlserver"
     valuetype          = "INT64"
     dataBase           = "sqlserver"
   }
@@ -1260,11 +1340,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/sqlserver/audits_upload_count"
     label              = "Total number of successfully uploaded audits."
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "sqlserver"
     valuetype          = "INT64"
     dataBase           = "sqlserver"
   }
-  primary_to_replica_connection_health = {
+  external_sync_primary_to_replica_connection_health = {
     type               = "gauge"
     description        = <<-EOF
                     Indicates whether there is connectivity from Primary to the Replica to push replication updates.
@@ -1272,11 +1352,11 @@ UNKNOWN_STATE: The state of the instance is unknown.
     launchStage        = "ALPHA"
     rollup             = "avg"
     aggregate          = "sum"
-    metricCategory     = "none"
+    metricCategory     = "external_sync"
     google_metric_path = "cloudsql.googleapis.com/database/sqlserver/external_sync/primary_to_replica_connection_health"
     label              = "Primary to Replica connectivity"
     unit               = ""
-    metricBin          = "['']"
+    metricBin          = "sqlserver"
     valuetype          = "BOOL"
     dataBase           = "sqlserver"
   }
@@ -1299,7 +1379,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/state"
     label              = "State"
     unit               = ""
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "STRING"
     dataBase           = "ALL"
   }
@@ -1315,7 +1395,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/up"
     label              = "Server up"
     unit               = "1"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }
@@ -1331,7 +1411,7 @@ UNKNOWN_STATE: The state of the instance is unknown.
     google_metric_path = "cloudsql.googleapis.com/database/uptime"
     label              = "Uptime"
     unit               = "s"
-    metricBin          = "['database']"
+    metricBin          = "ALL"
     valuetype          = "INT64"
     dataBase           = "ALL"
   }

--- a/service/cloudsql/local_metricdescriptors_over_rides.tf
+++ b/service/cloudsql/local_metricdescriptors_over_rides.tf
@@ -1,0 +1,23 @@
+locals {
+  override_keys = keys(local.metrics_definitions_overrides)
+  # if local.metrics_definitions has an overide value in local.metrics_definitions_overrides then use value from local.metrics_definitions_overrides
+  merged_metrics_definitions = { for key1, value1 in local.metrics_definitions : # loop
+    key1 => {
+      for key2, value2 in value1 :
+      key2 => contains(local.override_keys, key1) ?                     # check if metric key in override map
+      contains(keys(local.metrics_definitions_overrides[key1]), key2) ? # check if property in override map for given key
+      local.metrics_definitions_overrides[key1][key2] : value2          # use if present otherwise use existing
+      : value2                                                          # otherwise use existing
+    }
+  }
+
+
+
+  metrics_definitions_overrides = {
+    cpu_utilization = {
+      rollup = "rate"
+      unit   = "second"
+    }
+  }
+}
+

--- a/service/cloudsql/variables.tf
+++ b/service/cloudsql/variables.tf
@@ -50,11 +50,9 @@ variable "metric_interface_fields" {
   description = "Used by metric interface to pick fields to map"
 }
 
-variable "launch_stage" {
-  type = set(string)
-  default = [
-    "GA",
-  ]
+variable "metric_launch_stages" {
+  type        = set(string)
+  default     = ["GA", "BETA"]
   description = "Used by metric interface to pick metrics to include"
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes set_metric definition that was using incorrect name for metrics and didn't match value in metrics dataset

Updates metrics defintions

## Testing

tftests and alpha release
