### PR TITLE
ci: schedule daily ci test

### DIFF
--- a/.github/workflows/daily-ci.yaml
+++ b/.github/workflows/daily-ci.yaml
@@ -1,0 +1,16 @@
+name: Daily tftests run
+
+on:
+  workflow_dispatch:
+  # every day at 10pm PST
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  daily-ci-tests:
+    uses: observeinc/.github/.github/workflows/terraform-observe_scheduler.yaml@main
+    secrets: inherit
+    with:
+      # you can opt out of ci-tests scheduled by adding a list of "jobs" ids for the 
+      # tests that you want to skip, like so...
+      skip: '{"jobs": ["conventional-commits", "single-commit"]}'


### PR DESCRIPTION
## What does this PR do?

Schedules a daily CI tftest at 10pm PST

## Motivation

We've been getting bit by painful errors that reach staging, so a daily CI test would help catch them quickly.

## Testing

Haven't really, but should be fine.