### PR TITLE
feat: separate + add support for playwright testing

### DIFF
--- a/sample_infrastructure/service_modules/cloud_run/avocano/provisioning/deploy.cloudbuild.yaml
+++ b/sample_infrastructure/service_modules/cloud_run/avocano/provisioning/deploy.cloudbuild.yaml
@@ -50,35 +50,15 @@ steps:
     env:
       - PROJECT_ID=$PROJECT_ID
       - AVOCANO_PURCHASE_MODE=$_PURCHASE_MODE
-    script: |
+    script: | 
       #!/bin/bash
 
       npm i
       npm run build
       firebase deploy --project $PROJECT_ID --only hosting
-
-  # Optionally run tests, confirming deployment (run with '--substitutions=_RUN_TESTS=yes')
-  - id: "test deployment"
-    name: python:3.11-slim
-    dir: provisioning
-    env:
-      - _RUN_TESTS=$_RUN_TESTS
-      - AVOCANO_PURCHASE_MODE=$_PURCHASE_MODE
-    script: |
-      #!/bin/bash
-      if [ -z $_RUN_TESTS ]; then
-        echo "_RUN_TESTS not defined, so not running tests."
-        exit 0
-      fi
-
-      python -m pip install -r test/requirements.txt
-      playwright install-deps
-      playwright install
-      python -m pytest
-
+ 
 timeout: 1800s
 
 substitutions:
   _REGION: us-central1
-  _RUN_TESTS: ""
   _PURCHASE_MODE: ""

--- a/sample_infrastructure/service_modules/cloud_run/avocano/provisioning/test-deployment.yaml
+++ b/sample_infrastructure/service_modules/cloud_run/avocano/provisioning/test-deployment.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build client code into container
+# Used for Cloud Run Job-based deployment strategies
+
+steps:
+  - id: "test deployment"
+    name: python:3.11-slim
+    dir: provisioning
+    env:  
+      - AVOCANO_PURCHASE_MODE=$_PURCHASE_MODE
+      - PROJECT_ID=$PROJECT_ID
+      - REGION=$_REGION
+    script: |
+      #!/bin/bash  
+      python -m pip install -r test/requirements.txt
+      playwright install-deps
+      playwright install
+      python -m pytest
+
+
+substitutions:
+  _REGION: us-central1
+  _PURCHASE_MODE: ""
+
+

--- a/sample_infrastructure/service_modules/cloud_run/avocano/setup.sh
+++ b/sample_infrastructure/service_modules/cloud_run/avocano/setup.sh
@@ -68,8 +68,11 @@ function deploy {
   echo "Running Cloud Build for the Application"
   gcloud builds submit --config provisioning/deploy.cloudbuild.yaml --substitutions _REGION=${REGION}
 
-  echo "Setup database"
+  echo "Setting up database"
   gcloud beta run jobs execute setup --wait --region $REGION
+
+  echo "Runing UI tests" 
+  gcloud builds submit --config provisioning/test-deployment.yaml  --substitutions _REGION="${REGION}"
 
   echo "Website now available at https://${PROJECT_ID}.firebaseapp.com"
 }


### PR DESCRIPTION
Adding Playwright support for Deployment testing

Tested via deploy / destroy few times for graceful cleanup and setup

Example of Test:

```
============================= test session starts ==============================
platform linux -- Python 3.11.3, pytest-7.3.0, pluggy-1.0.0
rootdir: /workspace/provisioning
plugins: base-url-2.0.0, anyio-3.6.2, playwright-0.3.2
collected 9 items

test/client_test.py ...s                                                 [ 44%]
test/server_test.py .....                                                [100%]

========================= 8 passed, 1 skipped in 7.80s =========================
```