### PR TITLE
feat: surround metrics alias with feature flag

### DIFF
--- a/service/bigquery/main.tf
+++ b/service/bigquery/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   freshness = merge({
     bigquery = "5m",
     metrics  = "1m",

--- a/service/bigquery/metrics.tf
+++ b/service/bigquery/metrics.tf
@@ -76,7 +76,9 @@ resource "observe_dataset" "bigquery_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_bigquery"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/cloudfunctions/main.tf
+++ b/service/cloudfunctions/main.tf
@@ -2,6 +2,7 @@ locals {
   cloud_functions_monitoring_v2_dashboard_enable      = 1
   cloud_functions_monitoring_v2_dashboard_description = "Cloud Functions Monitoring Dashboard"
   cloud_functions_monitoring_v2_dashboard_name        = format(var.name_format, "Monitoring")
+  enable_metric_dataset_alias                         = lookup(var.feature_flags, "metric_explorer", false)
 
   cloud_functions_instances = resource.observe_dataset.cloud_functions_instances.id
   cloud_functions_metrics   = resource.observe_dataset.cloud_functions_metrics[0].id

--- a/service/cloudfunctions/metrics.tf
+++ b/service/cloudfunctions/metrics.tf
@@ -48,7 +48,9 @@ resource "observe_dataset" "cloud_functions_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_function"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/cloudsql/main.tf
+++ b/service/cloudsql/main.tf
@@ -1,9 +1,10 @@
 locals {
   freshness = merge({}, var.freshness_overrides)
 
-  enable_metrics  = lookup(var.feature_flags, "metrics", true)
-  enable_monitors = lookup(var.feature_flags, "monitors", true)
-  enable_both     = local.enable_monitors && local.enable_metrics
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_monitors             = lookup(var.feature_flags, "monitors", true)
+  enable_both                 = local.enable_monitors && local.enable_metrics
 
   /*
 

--- a/service/cloudsql/metrics.tf
+++ b/service/cloudsql/metrics.tf
@@ -74,7 +74,9 @@ resource "observe_dataset" "cloud_sql_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_sql"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,
@@ -116,7 +118,9 @@ resource "observe_dataset" "cloud_sql_metrics_combo" {
       make_col combo_metric: "all_database_network_connections"
 
       interface "metric", metric:combo_metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_sql_comb"
+      %{endif}
       set_metric options(
         aggregate: "sum",
         description: "Combination of network connection metrics.\n",
@@ -209,7 +213,9 @@ resource "observe_dataset" "cloud_sql_metrics_wide" {
   stage {
     pipeline = <<-EOF
         interface "metric", metric:metric, value:value
+        %{if local.enable_metric_dataset_alias}
         set_dataset_alias "gcp_sql_wide"
+        %{endif}
         set_metric options(
           aggregate: "sum",
           description: "Percentage of disk quota used\n",

--- a/service/compute/main.tf
+++ b/service/compute/main.tf
@@ -1,7 +1,8 @@
 
 locals {
 
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/compute/metrics.tf
+++ b/service/compute/metrics.tf
@@ -107,7 +107,9 @@ resource "observe_dataset" "compute_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_compute"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/loadbalancing/main.tf
+++ b/service/loadbalancing/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/loadbalancing/metrics.tf
+++ b/service/loadbalancing/metrics.tf
@@ -110,7 +110,9 @@ resource "observe_dataset" "load_balancing_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_lb"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/pubsub/main.tf
+++ b/service/pubsub/main.tf
@@ -1,7 +1,8 @@
 
 locals {
   # tflint-ignore: terraform_unused_declarations
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
   # tflint-ignore: terraform_unused_declarations

--- a/service/pubsub/metrics_subscriptions.tf
+++ b/service/pubsub/metrics_subscriptions.tf
@@ -94,7 +94,9 @@ resource "observe_dataset" "pubsub_subscription_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_pubsub_sub"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/pubsub/metrics_topic.tf
+++ b/service/pubsub/metrics_topic.tf
@@ -89,7 +89,9 @@ resource "observe_dataset" "pubsub_topic_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_pubsub_topic"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/pubsub/services.tf
+++ b/service/pubsub/services.tf
@@ -119,7 +119,9 @@ resource "observe_dataset" "pubsub_service_api_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_pubsub_api"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.service_metrics_definitions :
       indent(2,
@@ -134,7 +136,9 @@ if(contains(var.metric_launch_stages, options.launchStage) && options.metricBin 
 stage {
   pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_pubsub_api"
+      %{endif}
       ${join("\n\n",
   [for metric, options in local.merged_metrics_definitions_service :
     indent(2,
@@ -220,7 +224,9 @@ resource "observe_dataset" "pubsub_service_quota_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_pubsub_quota"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions_service :
       indent(2,

--- a/service/redis/main.tf
+++ b/service/redis/main.tf
@@ -1,7 +1,8 @@
 locals {
   freshness = merge({}, var.freshness_overrides)
 
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/redis/metrics.tf
+++ b/service/redis/metrics.tf
@@ -107,7 +107,9 @@ resource "observe_dataset" "redis_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_redis"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,

--- a/service/storage/main.tf
+++ b/service/storage/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enable_metrics = lookup(var.feature_flags, "metrics", true)
+  enable_metrics              = lookup(var.feature_flags, "metrics", true)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/storage/metrics.tf
+++ b/service/storage/metrics.tf
@@ -86,7 +86,9 @@ resource "observe_dataset" "storage_metrics" {
   stage {
     pipeline = <<-EOF
       interface "metric", metric:metric, value:value
+      %{if local.enable_metric_dataset_alias}
       set_dataset_alias "gcp_storage"
+      %{endif}
       ${join("\n\n",
     [for metric, options in local.merged_metrics_definitions :
       indent(2,


### PR DESCRIPTION
## What does this PR do?

- Protect each set_dataset_alias with a feature_flag

## Motivation

- To ensure unwanted behavior doesn't happen until set_dataset_alias is rolled into production

## Testing

- Cut Prerelease
- Deploy into Staging
- Ensure app worked as expected
