### PR TITLE
fix: add user facing feature_flag input var

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module "google" {
 | <a name="input_enable_service_pubsub"></a> [enable\_service\_pubsub](#input\_enable\_service\_pubsub) | Enable Pub Sub service. | `bool` | `true` | no |
 | <a name="input_enable_service_redis"></a> [enable\_service\_redis](#input\_enable\_service\_redis) | Enable Redis service. | `bool` | `true` | no |
 | <a name="input_enable_service_storage"></a> [enable\_service\_storage](#input\_enable\_service\_storage) | Enable Cloud Storage service. | `bool` | `true` | no |
-| <a name="input_feature_flags"></a> [feature\_flags](#input\_feature\_flags) | Toggle features which are being rolled out or phased out. | `map(bool)` | `{}` | no |
+| <a name="input_feature_flags"></a> [feature\_flags](#input\_feature\_flags) | List of feature flags. This field is experimental, please contact support for guidance. | `list(string)` | `[]` | no |
 | <a name="input_freshness_default_duration"></a> [freshness\_default\_duration](#input\_freshness\_default\_duration) | Default dataset freshness. Can be overridden with freshness input | `string` | `"5m"` | no |
 | <a name="input_freshness_overrides"></a> [freshness\_overrides](#input\_freshness\_overrides) | Freshness overrides by dataset. If absent, fall back to freshness\_duration\_default | `map(string)` | `{}` | no |
 | <a name="input_max_expiry"></a> [max\_expiry](#input\_max\_expiry) | Maximum expiry time for resources. | `string` | `"4h"` | no |

--- a/bookmarks.tf
+++ b/bookmarks.tf
@@ -1,6 +1,6 @@
 
 locals {
-  enable_bookmarks = lookup(var.feature_flags, "bookmarks", true)
+  enable_bookmarks = lookup(local.feature_flags, "bookmarks", true)
 }
 
 

--- a/enable.tf
+++ b/enable.tf
@@ -6,6 +6,10 @@
 # - enable_service_* variable usages in apps/main.tf
 locals {
 
+  # generate local.feature_flags map from var.feature_flags list(string) 
+  # ["foo", "!bar"] turns into {foo: true, bar: false}
+  feature_flags = { for item in var.feature_flags : trimprefix(item, "!") => trimprefix(item, "!") == item }
+
   enable_service_bigquery = (
     var.enable_service_bigquery == true ||
     # var.enable_service_bigquery ||
@@ -106,7 +110,7 @@ module "cloudfunctions" {
   name_format                = format(var.name_format, local.name_format_cloudfunctions)
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -119,7 +123,7 @@ module "cloudsql" {
   name_format                = format(var.name_format, local.name_format_cloudsql)
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -132,7 +136,7 @@ module "compute" {
   name_format                = format(var.name_format, local.name_format_compute)
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
   # iam_asset_binding          = one(module.iam[*].asset_binding)
 
   google = local.base_module
@@ -147,7 +151,7 @@ module "storage" {
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
   freshness_overrides        = var.freshness_overrides
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -161,7 +165,7 @@ module "load_balancing" {
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
   freshness_overrides        = var.freshness_overrides
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -174,7 +178,7 @@ module "bigquery" {
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
   # freshness_overrides = var.freshness_overrides
-  feature_flags = var.feature_flags
+  feature_flags = local.feature_flags
   google        = local.base_module
 }
 module "pubsub" {
@@ -186,7 +190,7 @@ module "pubsub" {
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
   freshness_overrides        = var.freshness_overrides
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -213,7 +217,7 @@ module "gke" {
   max_expiry                 = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
   freshness_overrides        = var.freshness_overrides
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = merge(local.base_module, {
     compute_instance_group                  = one(module.compute[*].compute_instance_group)
@@ -259,7 +263,7 @@ module "redis" {
   name_format                = format(var.name_format, local.name_format_redis)
   max_expiry_duration        = var.max_expiry
   freshness_default_duration = var.freshness_default_duration
-  feature_flags              = var.feature_flags
+  feature_flags              = local.feature_flags
 
   google = local.base_module
 }
@@ -272,7 +276,7 @@ module "redis" {
 #   name_format                = format(var.name_format, local.name_format_memcache)
 #   max_expiry_duration        = var.max_expiry
 #   freshness_default_duration = var.freshness_default_duration
-#   feature_flags              = var.feature_flags
+#   feature_flags              = local.feature_flags
 
 #   google = local.base_module
 # }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
     projects                           = observe_dataset.projects_collection_enabled
     distribution_metrics               = observe_dataset.process_distribution_metrics
   }
-  # enable_metrics = lookup(var.feature_flags, "metrics", true)
+  # enable_metrics = lookup(local.feature_flags, "metrics", true)
 
 }
 resource "observe_dataset" "base_pubsub_events" {

--- a/tftests/all_services_all_opts/main.tf
+++ b/tftests/all_services_all_opts/main.tf
@@ -27,8 +27,10 @@ module "all_services_all_opts" {
   enable_service_redis          = true
   # enable_service_memcache       = true
 
-  feature_flags = {
-    "use_name_format_in_preferred_path" = true
-  }
+  feature_flags = [
+    "use_name_format_in_preferred_path",
+    "metrics_explorer"
+  ]
+
   freshness_default_duration = var.freshness_default_duration
 }

--- a/tftests/all_services_def_opts/main.tf
+++ b/tftests/all_services_def_opts/main.tf
@@ -22,7 +22,5 @@ module "all_services_def_opts" {
   enable_service_storage        = true
   enable_service_bigquery       = true
 
-  feature_flags = {
-    "use_name_format_in_preferred_path" = true
-  }
+  feature_flags = ["use_name_format_in_preferred_path"]
 }

--- a/tftests/default/main.tf
+++ b/tftests/default/main.tf
@@ -10,11 +10,9 @@ data "observe_datastream" "default" {
 }
 
 module "default" {
-  source      = "../.."
-  workspace   = data.observe_workspace.default
-  datastream  = data.observe_datastream.default
-  name_format = "test_gcp_${random_pet.test.id}/%s"
-  feature_flags = {
-    "use_name_format_in_preferred_path" = true
-  }
+  source        = "../.."
+  workspace     = data.observe_workspace.default
+  datastream    = data.observe_datastream.default
+  name_format   = "test_gcp_${random_pet.test.id}/%s"
+  feature_flags = ["use_name_format_in_preferred_path"]
 }

--- a/tftests/no_services_no_opts/main.tf
+++ b/tftests/no_services_no_opts/main.tf
@@ -15,29 +15,17 @@ module "default" {
   datastream  = data.observe_datastream.default
   name_format = "test_gcp_${random_pet.test.id}/%s"
 
-  enable_service_bigquery = false
-
+  enable_service_bigquery       = false
   enable_service_cloudfunctions = false
-
-  enable_service_cloudsql = false
-
-  enable_service_compute = false
-
-  enable_service_storage = false
-
+  enable_service_cloudsql       = false
+  enable_service_compute        = false
+  enable_service_storage        = false
   enable_service_load_balancing = false
-
-  enable_service_pubsub = false
-
+  enable_service_pubsub         = false
   enable_service_cloudscheduler = false
+  enable_service_gke            = false
+  enable_service_redis          = false
+  # enable_service_memcache       = false
 
-  enable_service_gke = false
-
-  enable_service_redis = false
-
-  # enable_service_memcache = false
-
-  feature_flags = {
-    "use_name_format_in_preferred_path" = true
-  }
+  feature_flags = ["use_name_format_in_preferred_path"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,9 +45,9 @@ variable "freshness_overrides" {
 }
 
 variable "feature_flags" {
-  type        = map(bool)
-  description = "Toggle features which are being rolled out or phased out."
-  default     = {}
+  type        = list(string)
+  description = "List of feature flags. This field is experimental, please contact support for guidance."
+  default     = []
 }
 
 variable "services" {


### PR DESCRIPTION
## What does this PR do?

Changes the variable `feature_flags` from a `map(bool)` to a `list(string)` type. This exposes the feature_flag variable to app installers so that they can enable/disable beta features by inputting the correct feature flag strings. 

If you enter "foo" it will enable the feature flag "foo". If you enter "!foo" it will disable the feature flag foo.  

Inspiration for this feature_flag method is the [AWS app](https://github.com/observeinc/terraform-observe-aws/blob/main/app/main.tf#L15)

## Motivation

Make it easier to test beta features via app installs. 

## Testing

tftests pass locally. Tested a pre-release in staging, works nicely. 
