### PR TITLE
fix: remove duplicates from resource assets

### DIFF
--- a/asset_inventory.tf
+++ b/asset_inventory.tf
@@ -79,7 +79,7 @@ resource "observe_dataset" "resource_asset_inventory_records" {
   stage {
     input    = "events"
     pipeline = <<-EOF
-          filter not is_null(resource)
+          filter (resource != object(parse_json("{}"))) and not is_null(resource)
 
           make_col 
             ttl: case(deleted, 1ns, true, 4h),


### PR DESCRIPTION
## What does this PR do?

- Updates the Resource Asset Inventory Records' filter to ensure no duplicate resources.

## Motivation

- Discovered during load and asset inventory testing

## Testing

- Cut a prerelease
- ensure OPAL works properly
