### PR TITLE
fix: gkeClusterAssetKey in GKE Logs

### DIFF
--- a/service/gke/logs.tf
+++ b/service/gke/logs.tf
@@ -30,8 +30,9 @@ resource "observe_dataset" "gke_logs" {
             k8sio_deprecated:string(labels['k8s.io/deprecated']),
             k8sio_removed_release:string(labels['k8s.io/removed-release'])
             
+        make_col cluster_type:if(match_regex(location, /[^\-]*-[^\-]*-/, "i"), "/zones/", "/locations/")
 
-        make_col gkeClusterAssetKey: string_concat("//container.googleapis.com/projects/", project_id, "/locations/", location, "/clusters/",cluster_name)
+        make_col gkeClusterAssetKey: concat_strings("//container.googleapis.com/projects/", project_id, cluster_type, location, "/clusters/",cluster_name)
     EOF
   }
 


### PR DESCRIPTION
## What does this PR do?

- Fix gkeClusterAssetKey in GKE Logs.  It will be different if the Cluster is deployed in Zones vs a Region

## Motivation

- Users will be unable to GraphLink to GKE Logs form GKE Cluster Resource unless this fix is put in place

## Testing

- Cut a prerelease
- Deployed to internally used Production account
- ensured the fix worked
