### PR TITLE
feat: ability to handle data from GCP Collection's exportAssets API

### DIFF
--- a/service/bigquery/resources.tf
+++ b/service/bigquery/resources.tf
@@ -45,7 +45,6 @@ resource "observe_dataset" "bigquery_table" {
   stage {
     input    = "events"
     pipeline = <<-EOF
-        filter contains(asset_type, "bigquery")
         filter asset_type = "bigquery.googleapis.com/Table"
         make_col dataset_id:string(data.tableReference.datasetId),
             project_id:string(data.tableReference.projectId),


### PR DESCRIPTION
## What does this PR do?

- adds a stage to Asset Inventory Records to handle new asset collection method from Observe's Google Collection

## Testing

- Ran Python scripts locally that exported and published GCP resources with new exportAssets API.
- Verified all Resources populated correctly