### PR TITLE
fix: statically extracted region in GKE Clusters

### DIFF
--- a/service/gke/clusters.tf
+++ b/service/gke/clusters.tf
@@ -70,7 +70,7 @@ resource "observe_dataset" "gke_events" {
         make_col ttl: case(deleted, 1ns, true, 4h)
 
         extract_regex name, /projects\/(?P<project_id>[^\/]+)/
-        extract_regex name, /locations\/(?P<region>[^\/]+)/
+        extract_regex name, /\/\/([^\/]*\/){4}(?P<region>[^\-]*-[^\-]*).*\//
 
     EOF
   }


### PR DESCRIPTION
## What does this PR do?

- Dynamically extracts the GCP GKE Regions instead of using "locations" as an anchor 

## Motivation

Internal demo environments needed it


## Testing

- Deployed a prerelease to Staging and Production - both looked good.
