### PR TITLE
chore: disable scheduled cypress tests

### DIFF
--- a/.github/workflows/ci-cypress-tests.yaml
+++ b/.github/workflows/ci-cypress-tests.yaml
@@ -8,10 +8,10 @@ on:
   #     - 'main'
   # pull_request:
 
-  schedule:
-    # only runs on default branch
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '5 */12 * * *'
+  # schedule:
+  #   # only runs on default branch
+  #   # * is a special character in YAML so you have to quote this string
+  #   - cron:  '5 */12 * * *'
 
 jobs:
   


### PR DESCRIPTION
## What does this PR do?

- Disables scheduled cypress tests on this repo 
- Will be reenabled after https://observe.atlassian.net/browse/CON-1090 is complete 

