### PR TITLE
fix: update metrics_alias flag to true

### DIFF
--- a/service/bigquery/main.tf
+++ b/service/bigquery/main.tf
@@ -1,6 +1,6 @@
 locals {
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   freshness = merge({
     bigquery = "5m",
     metrics  = "1m",

--- a/service/cloudfunctions/main.tf
+++ b/service/cloudfunctions/main.tf
@@ -2,7 +2,7 @@ locals {
   cloud_functions_monitoring_v2_dashboard_enable      = 1
   cloud_functions_monitoring_v2_dashboard_description = "Cloud Functions Monitoring Dashboard"
   cloud_functions_monitoring_v2_dashboard_name        = format(var.name_format, "Monitoring")
-  enable_metric_dataset_alias                         = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias                         = lookup(var.feature_flags, "metric_explorer", true)
 
   cloud_functions_instances = resource.observe_dataset.cloud_functions_instances.id
   cloud_functions_metrics   = resource.observe_dataset.cloud_functions_metrics[0].id

--- a/service/cloudsql/main.tf
+++ b/service/cloudsql/main.tf
@@ -2,7 +2,7 @@ locals {
   freshness = merge({}, var.freshness_overrides)
 
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   enable_monitors             = lookup(var.feature_flags, "monitors", true)
   enable_both                 = local.enable_monitors && local.enable_metrics
 

--- a/service/compute/main.tf
+++ b/service/compute/main.tf
@@ -2,7 +2,7 @@
 locals {
 
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/loadbalancing/main.tf
+++ b/service/loadbalancing/main.tf
@@ -1,6 +1,6 @@
 locals {
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/pubsub/main.tf
+++ b/service/pubsub/main.tf
@@ -2,7 +2,7 @@
 locals {
   # tflint-ignore: terraform_unused_declarations
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
   # tflint-ignore: terraform_unused_declarations

--- a/service/redis/main.tf
+++ b/service/redis/main.tf
@@ -2,7 +2,7 @@ locals {
   freshness = merge({}, var.freshness_overrides)
 
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/service/storage/main.tf
+++ b/service/storage/main.tf
@@ -1,6 +1,6 @@
 locals {
   enable_metrics              = lookup(var.feature_flags, "metrics", true)
-  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", false)
+  enable_metric_dataset_alias = lookup(var.feature_flags, "metric_explorer", true)
   # tflint-ignore: terraform_unused_declarations
   enable_monitors = lookup(var.feature_flags, "monitors", true)
 

--- a/tftests/all_services_all_opts/main.tf
+++ b/tftests/all_services_all_opts/main.tf
@@ -29,7 +29,7 @@ module "all_services_all_opts" {
 
   feature_flags = [
     "use_name_format_in_preferred_path",
-    "metrics_explorer"
+    "metrics_explorer:false"
   ]
 
   freshness_default_duration = var.freshness_default_duration


### PR DESCRIPTION
## What does this PR do?

Required - Update enable_metrics_alias flag to set to true for GA of metrics_explorer feature.
JIRA - https://observe.atlassian.net/browse/CON-1360

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - Tested in staging and it worked. 
