### PR TITLE
fix: set redis network traffic graphs to rate

### DIFF
--- a/service/redis/db_monitoring.tf
+++ b/service/redis/db_monitoring.tf
@@ -1,4 +1,4 @@
-# terraform import observe_dashboard.redis_monitoring 41745727
+# terraform import observe_dashboard.redis_monitoring 42909069
 resource "observe_dashboard" "redis_monitoring" {
   description = local.dashboard_description
   layout = jsonencode(
@@ -10,7 +10,7 @@ resource "observe_dashboard" "redis_monitoring" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-1hrwz0fj"
+              id       = "card-ykwek5af"
               title    = "Untitled Section"
             }
             items = []
@@ -19,116 +19,92 @@ resource "observe_dashboard" "redis_monitoring" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "card-pjpvodz0"
+              id       = "card-gq0xqleb"
               title    = "Summary"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-vcz0s4n3"
+                  id       = "card-ucrq2g0o"
                   stageId  = "stage-gd5a7ls5"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-vcz0s4n3"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 6
-                  y           = 0
+                  h = 11
+                  i = "card-ucrq2g0o"
+                  w = 2
+                  x = 6
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-mx6d3xe2"
+                  id       = "card-5p8l1ce1"
                   stageId  = "stage-q5223la6"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-mx6d3xe2"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 4
-                  y           = 0
+                  h = 11
+                  i = "card-5p8l1ce1"
+                  w = 2
+                  x = 4
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-vjgzych5"
+                  id       = "card-tkebrzkz"
                   stageId  = "stage-kkg69631"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-vjgzych5"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 8
-                  y           = 0
+                  h = 11
+                  i = "card-tkebrzkz"
+                  w = 2
+                  x = 8
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-svv9dr7i"
+                  id       = "card-il6i1lxc"
                   stageId  = "stage-95dn11kb"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-svv9dr7i"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 10
-                  y           = 0
+                  h = 11
+                  i = "card-il6i1lxc"
+                  w = 2
+                  x = 10
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-yb0odp2r"
+                  id       = "card-8l0g4evt"
                   stageId  = "stage-sblyl8hv"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-yb0odp2r"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 0
-                  y           = 0
+                  h = 11
+                  i = "card-8l0g4evt"
+                  w = 2
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-r034fkxl"
+                  id       = "card-p4c7s55i"
                   stageId  = "stage-z5l9wra8"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-r034fkxl"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 2
-                  y           = 0
+                  h = 11
+                  i = "card-p4c7s55i"
+                  w = 2
+                  x = 2
+                  y = 0
                 }
               },
             ]
@@ -138,116 +114,92 @@ resource "observe_dashboard" "redis_monitoring" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-i19xn7rx"
+              id       = "card-okpfhe0u"
               title    = "Monitoring"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-ffmn95en"
+                  id       = "card-loacysqv"
                   stageId  = "stage-m6kykgl1"
                 }
                 layout = {
-                  h           = 19
-                  i           = "card-ffmn95en"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 5
-                  x           = 7
-                  y           = 0
+                  h = 19
+                  i = "card-loacysqv"
+                  w = 5
+                  x = 7
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-fj9vimnu"
+                  id       = "card-fxtxltqt"
                   stageId  = "stage-5il4u0ht"
                 }
                 layout = {
-                  h           = 10
-                  i           = "card-fj9vimnu"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 7
-                  x           = 0
-                  y           = 0
+                  h = 10
+                  i = "card-fxtxltqt"
+                  w = 7
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-ul9r334r"
+                  id       = "card-le2wcr8z"
                   stageId  = "stage-ltpfsi5n"
                 }
                 layout = {
-                  h           = 9
-                  i           = "card-ul9r334r"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 7
-                  x           = 0
-                  y           = 8
+                  h = 9
+                  i = "card-le2wcr8z"
+                  w = 7
+                  x = 0
+                  y = 10
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-cby308vv"
+                  id       = "card-2rz3mq6i"
                   stageId  = "stage-4vx5oqwq"
                 }
                 layout = {
-                  h           = 12
-                  i           = "card-cby308vv"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 8
-                  y           = 17
+                  h = 12
+                  i = "card-2rz3mq6i"
+                  w = 4
+                  x = 8
+                  y = 19
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-dsjuagqo"
+                  id       = "card-a565f3f6"
                   stageId  = "stage-xa7yo712"
                 }
                 layout = {
-                  h           = 12
-                  i           = "card-dsjuagqo"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 4
-                  y           = 17
+                  h = 12
+                  i = "card-a565f3f6"
+                  w = 4
+                  x = 4
+                  y = 19
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-9espvsrs"
+                  id       = "card-aw85e1ak"
                   stageId  = "stage-xmeu7adi"
                 }
                 layout = {
-                  h           = 12
-                  i           = "card-9espvsrs"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 0
-                  y           = 17
+                  h = 12
+                  i = "card-aw85e1ak"
+                  w = 4
+                  x = 0
+                  y = 19
                 }
               },
             ]
@@ -257,98 +209,78 @@ resource "observe_dashboard" "redis_monitoring" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-ft8jerr3"
+              id       = "card-nocx01u5"
               title    = "Keys"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-6f5r2354"
+                  id       = "card-7c1ajq10"
                   stageId  = "stage-9y2jp9iw"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-6f5r2354"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 7
-                  x           = 5
-                  y           = 0
+                  h = 11
+                  i = "card-7c1ajq10"
+                  w = 7
+                  x = 5
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-7t6mn4so"
+                  id       = "card-jx4653zt"
                   stageId  = "stage-5flbedut"
                 }
                 layout = {
-                  h           = 22
-                  i           = "card-7t6mn4so"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 0
-                  y           = 0
+                  h = 22
+                  i = "card-jx4653zt"
+                  w = 2
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-mu054jxi"
+                  id       = "card-ghl5od53"
                   stageId  = "stage-f935xw0s"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-mu054jxi"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 2
-                  y           = 0
+                  h = 11
+                  i = "card-ghl5od53"
+                  w = 3
+                  x = 2
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-2zvn76nh"
+                  id       = "card-phvavoqg"
                   stageId  = "stage-9x9a8h1f"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-2zvn76nh"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 7
-                  x           = 5
-                  y           = 0
+                  h = 11
+                  i = "card-phvavoqg"
+                  w = 7
+                  x = 5
+                  y = 11
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-y5bhgr41"
+                  id       = "card-uijx2o45"
                   stageId  = "stage-pwabkz2q"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-y5bhgr41"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 2
-                  y           = 0
+                  h = 11
+                  i = "card-uijx2o45"
+                  w = 3
+                  x = 2
+                  y = 11
                 }
               },
             ]
@@ -358,65 +290,53 @@ resource "observe_dashboard" "redis_monitoring" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-5yf1rwfj"
+              id       = "card-s4liuycf"
               title    = "Documentation"
             }
             items = [
               {
                 card = {
                   cardType = "text"
-                  id       = "card-r4fj9zi6"
+                  id       = "card-q82nmp1i"
                   text     = <<-EOT
                                         ### Memorystore for Redis
-                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                        
                                         [https://cloud.google.com/memorystore/docs/redis/redis-overview](https://cloud.google.com/memorystore/docs/redis/redis-overview)
-                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                        
                                         Memorystore for Redis provides a fully-managed service that is powered by the Redis in-memory data store to build application caches that provide sub-millisecond data access.
-                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                        
                                         ### Use cases for Memorystore for Redis
-                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                        
                                         Memorystore for Redis provides a fast, in-memory store for use cases that require fast, real-time processing of data. From simple caching use cases to real time analytics, Memorystore for Redis provides the performance you need.
-                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                          
                                     EOT
                   title    = "Untitled Text"
                 }
                 layout = {
-                  h           = 14
-                  i           = "card-r4fj9zi6"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 6
-                  x           = 0
-                  y           = 0
+                  h = 14
+                  i = "card-q82nmp1i"
+                  w = 6
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "text"
-                  id       = "card-1yadvgu1"
+                  id       = "card-9qq3m6lp"
                   text     = <<-EOT
                                         ### Notes
                                         Metrics are sampled every 60s and may take up to 240s to display.
-                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                        
                                         To use this application you must implement the terraform-google-collection and the terraform google module with enable_service_redis set to true.
-                                                                                                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                                                                                              
                                     EOT
                   title    = "Untitled Text"
                 }
                 layout = {
-                  h           = 14
-                  i           = "card-1yadvgu1"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 6
-                  x           = 6
-                  y           = 0
+                  h = 14
+                  i = "card-9qq3m6lp"
+                  w = 6
+                  x = 6
+                  y = 0
                 }
               },
             ]
@@ -445,9 +365,9 @@ resource "observe_dashboard" "redis_monitoring" {
             viewType = "input"
           },
         ]
-        selectedStageId = "stage-debafcpb"
+        selectedStageId = "stage-ltpfsi5n"
         timeRange = {
-          display               = "Today 12:13:40 → 13:13:40"
+          display               = "Today 11:35:32 → 12:35:32"
           endTime               = null
           millisFromCurrentTime = 3600000
           originalDisplay       = "Past 60 minutes"
@@ -495,50 +415,7 @@ resource "observe_dashboard" "redis_monitoring" {
         ]
         layout = {
           appearance = "HIDDEN"
-          dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
-            columnOrderOverride = {
-              "1" = "Valid From"
-              "2" = "Valid To"
-            }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
-            selection = {
-              cells                = {}
-              columnSelectSequence = []
-              columns              = {}
-              highlightState       = {}
-              rows                 = {}
-              selectionType        = "table"
-            }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
-          }
-          index = 0
+          index      = 0
           inputList = [
             {
               datasetId   = local.redis_instance
@@ -567,7 +444,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "test_gcp_learning-bedbug/Redis Instance"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -575,10 +451,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-ezmooa2t"
@@ -590,10 +462,37 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  disabled = false
+                  hint     = "#hint{skipExistsNoFilter:true}"
+                }
+                summary = null
+                type    = "Hint"
+              }
+              customSummary = ""
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-wc5dp1qn"
+              index    = 1
+              isPinned = false
+              opal = [
+                "#hint{skipExistsNoFilter:true}",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -605,7 +504,10 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = "// Filtered Dataset Controlled Filter Stage"
+        pipeline = <<-EOT
+                    // Filtered Dataset Controlled Filter Stage
+                    #hint{skipExistsNoFilter:true}
+                EOT
       },
       {
         id = "stage-95dn11kb"
@@ -621,36 +523,19 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "_c_valid_from"
               "2" = "_c_valid_to"
               "3" = "Valid From"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -659,11 +544,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 1
           inputList = [
@@ -708,9 +589,14 @@ resource "observe_dashboard" "redis_monitoring" {
                       fn         = "avg"
                       resolution = "SINGLE"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "keyvalue"
-                    valueField    = "_ob_value"
+                    valueField    = "A__ob_value_avg"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -734,55 +620,22 @@ resource "observe_dashboard" "redis_monitoring" {
             resultKinds = [
               "ResultKindSchema",
             ]
-            rollup      = {}
-            wantBuckets = 600
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A__ob_value_avg"
+              },
+            ]
+            wantBuckets = 1
           }
           renderType     = "TABLE"
           selectedStepId = null
           serializable   = true
           steps = [
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  datacenter            = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-8f2vxszg"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -790,10 +643,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-meveek96"
@@ -819,7 +668,6 @@ resource "observe_dashboard" "redis_monitoring" {
                 type    = "Timechart"
               }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -827,10 +675,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-42jxcf50"
@@ -857,7 +701,6 @@ resource "observe_dashboard" "redis_monitoring" {
                 type    = "TopK"
               }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -865,10 +708,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-smau91h0"
@@ -880,13 +719,102 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "unknown"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "_ob_value"
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              keyField = [
+                                "state",
+                              ]
+                              statsBy = {
+                                fn = "avg"
+                              }
+                              timechart = {
+                                fn         = "avg"
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A__ob_value_avg"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy = [
+                          "state",
+                        ]
+                        id              = "datasetQueryExpression-38oboevq"
+                        inputSource     = "parentStageInputSource"
+                        lookupActions   = []
+                        summarizeVerb   = "statsby"
+                        summaryFunction = "avg"
+                        summaryMode     = "single"
+                        type            = "datasetQueryExpression"
+                        valueColumnId   = "A__ob_value_avg"
+                        viewTab         = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-z8d7itsc"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-38oboevq",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-azc8mrh4"
+              index    = 3
+              isPinned = false
+              opal = [
+                "statsby A__ob_value_avg:avg(_ob_value), group_by(state)",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = <<-EOT
-                            timechart options(empty_bins:true), _ob_value:count_distinct(state), group_by(state)
-                            topk 16, max(_ob_value)
-                        EOT
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -901,6 +829,7 @@ resource "observe_dashboard" "redis_monitoring" {
         pipeline = <<-EOT
                     timechart options(empty_bins:true), _ob_value:count_distinct(state), group_by(state)
                     topk 16, max(_ob_value)
+                    statsby A__ob_value_avg:avg(_ob_value), group_by(state)
                 EOT
       },
       {
@@ -924,36 +853,19 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -962,11 +874,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 2
           inputList = [
@@ -1018,7 +926,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_commands_calls_ybcszjy4"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1042,7 +950,7 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
@@ -1050,7 +958,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "commands_calls_from_GCP/Redis Metrics"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1058,10 +965,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-miimkhzs"
@@ -1072,25 +975,7 @@ resource "observe_dashboard" "redis_monitoring" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  hostname                       = "count"
-                  metric_commands_calls_ybcszjy4 = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-y5mboyp1"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1098,10 +983,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-2wzfhvmj"
@@ -1122,7 +1003,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1165,35 +1045,19 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -1202,11 +1066,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 3
           inputList = [
@@ -1258,7 +1118,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_cpu_utilization_8ieslylf"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1276,15 +1136,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1292,10 +1151,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-0h6suh18"
@@ -1307,7 +1162,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1315,10 +1169,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-3clsnsh3"
@@ -1339,7 +1189,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1382,54 +1231,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 4
           inputList = [
@@ -1480,7 +1303,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_keyspace_keys_gutc2399"
                   }
                   topK = {
-                    k     = 16
+                    k     = 100
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1498,15 +1321,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 50
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1514,10 +1336,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-8sp3ytp8"
@@ -1529,7 +1347,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1537,10 +1354,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-o2phd1zi"
@@ -1561,7 +1374,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1604,55 +1416,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 1311
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 5
           inputList = [
@@ -1701,7 +1486,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_clients_connected_3x4tfwpv"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1725,15 +1510,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1741,10 +1525,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-kjxngiz3"
@@ -1756,7 +1536,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1764,10 +1543,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-jbdsj9ch"
@@ -1788,7 +1563,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1831,35 +1605,19 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -1868,11 +1626,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 6
           inputList = [
@@ -1928,7 +1682,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_memory_usage_ratio_44v2388h"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1946,7 +1700,7 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
@@ -1954,7 +1708,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "stats_memory_usage_ratio_from_test_gcp_learning-bedbug/Redis Metrics"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1962,10 +1715,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-pvq3lxt2"
@@ -1977,7 +1726,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1985,10 +1733,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-0bozlyiv"
@@ -2007,7 +1751,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2047,54 +1790,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 7
           inputList = [
@@ -2131,8 +1848,9 @@ resource "observe_dashboard" "redis_monitoring" {
                     visible = true
                   }
                   yConfig = {
-                    unit    = "By"
-                    visible = true
+                    axisLabel = "Bytes/Second"
+                    unit      = "By"
+                    visible   = true
                   }
                 }
                 source = {
@@ -2146,7 +1864,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_network_traffic_5me9224l"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -2164,15 +1882,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2180,10 +1897,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-y4kuszgm"
@@ -2195,7 +1908,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2204,19 +1916,15 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindData",
                   "ResultKindStats",
                 ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
-                ]
               }
-              id       = "step-gqixl3h7"
+              id       = "step-8rsgb0h4"
               index    = 1
               isPinned = false
               opal = [
                 "@A <- @\"stats_network_traffic_from_GCP/Redis Metrics\" {",
                 "    filter role = \"primary\"",
                 "    join instance_pkey = @redis.instance_pkey",
-                "    align 2m, metric_stats_network_traffic_5me9224l:avg(m(\"stats_network_traffic\"))",
+                "    align metric_stats_network_traffic_5me9224l:rate(m(\"stats_network_traffic\"))",
                 "    aggregate metric_stats_network_traffic_5me9224l:sum(metric_stats_network_traffic_5me9224l), group_by(hostname)",
                 "}",
                 "<- @A {}",
@@ -2227,7 +1935,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2243,7 +1950,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     @A <- @"stats_network_traffic_from_GCP/Redis Metrics" {
                         filter role = "primary"
                         join instance_pkey = @redis.instance_pkey
-                        align 2m, metric_stats_network_traffic_5me9224l:avg(m("stats_network_traffic"))
+                        align metric_stats_network_traffic_5me9224l:rate(m("stats_network_traffic"))
                         aggregate metric_stats_network_traffic_5me9224l:sum(metric_stats_network_traffic_5me9224l), group_by(hostname)
                     }
                     <- @A {}
@@ -2270,54 +1977,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 8
           inputList = [
@@ -2369,7 +2050,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_connections_total_46w7dr1w"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -2387,15 +2068,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2403,10 +2083,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-c6yl476d"
@@ -2418,7 +2094,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2426,10 +2101,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-kfx4ez88"
@@ -2450,7 +2121,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2493,54 +2163,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 9
           inputList = [
@@ -2591,7 +2235,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_keyspace_avg_ttl_7s5qqdnq"
                   }
                   topK = {
-                    k     = 16
+                    k     = 100
                     order = "Top"
                     type  = "Auto"
                   }
@@ -2609,15 +2253,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2625,10 +2268,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-bitmvbp2"
@@ -2640,7 +2279,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2648,10 +2286,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-9rz6bmsb"
@@ -2672,7 +2306,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2715,54 +2348,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 10
           inputList = [
@@ -2813,7 +2420,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_expired_keys_wbhf0r7g"
                   }
                   topK = {
-                    k     = 16
+                    k     = 100
                     order = "Top"
                     type  = "Auto"
                   }
@@ -2831,15 +2438,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2847,10 +2453,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-b748og96"
@@ -2862,7 +2464,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2870,10 +2471,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-pivsl0wv"
@@ -2894,7 +2491,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2937,54 +2533,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 11
           inputList = [
@@ -3036,7 +2606,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_keyspace_hits_zk0gg3ud"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -3054,15 +2624,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3070,10 +2639,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-sxo4fg9d"
@@ -3085,7 +2650,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3093,10 +2657,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-33co3fso"
@@ -3117,7 +2677,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3160,54 +2719,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 12
           inputList = [
@@ -3261,7 +2794,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_stats_keyspace_misses_85e379pl"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -3279,15 +2812,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3295,10 +2827,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-hcgpv754"
@@ -3310,7 +2838,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3318,10 +2845,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-8i2zuwf2"
@@ -3342,7 +2865,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3385,54 +2907,28 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 13
           inputList = [
@@ -3484,7 +2980,7 @@ resource "observe_dashboard" "redis_monitoring" {
                     y             = "metric_keyspace_keys_with_expiration_ov8o9z71"
                   }
                   topK = {
-                    k     = 16
+                    k     = 25
                     order = "Top"
                     type  = "Auto"
                   }
@@ -3502,15 +2998,14 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 400
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "redis"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3518,10 +3013,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-w411f7au"
@@ -3533,7 +3024,6 @@ resource "observe_dashboard" "redis_monitoring" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3541,10 +3031,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-hg1v3wgw"
@@ -3565,7 +3051,6 @@ resource "observe_dashboard" "redis_monitoring" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3601,35 +3086,18 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "Valid From"
               "2" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 1311
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -3638,11 +3106,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 14
           inputList = [
@@ -3688,9 +3152,14 @@ resource "observe_dashboard" "redis_monitoring" {
                       fnArgs     = []
                       resolution = "SINGLE"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "keyvalue"
-                    valueField    = "project_id"
+                    valueField    = "A_project_id_count_distinct"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -3710,53 +3179,21 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_project_id_count_distinct"
+              },
+            ]
+            wantBuckets = 1
           }
           renderType     = "TABLE"
           selectedStepId = null
           serializable   = true
           steps = [
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-oqqfj25b"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3764,10 +3201,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-a5undelg"
@@ -3777,10 +3210,104 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "project_id"
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              keyField = [
+                                "project_id",
+                              ]
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count_distinct"
+                                fnArgs     = []
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_project_id_count_distinct"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy = [
+                          "project_id",
+                        ]
+                        id                  = "datasetQueryExpression-j101a6ko"
+                        inputSource         = "parentStageInputSource"
+                        lookupActions       = []
+                        summarizeVerb       = "statsby"
+                        summaryFunction     = "count_distinct"
+                        summaryFunctionArgs = []
+                        summaryMode         = "single"
+                        type                = "datasetQueryExpression"
+                        valueColumnId       = "A_project_id_count_distinct"
+                        viewTab             = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-rncipu6c"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-j101a6ko",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-nkzn4l2l"
+              index    = 1
+              isPinned = false
+              opal = [
+                "statsby A_project_id_count_distinct:count_distinct(project_id), group_by(project_id)",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3792,7 +3319,7 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = ""
+        pipeline = "statsby A_project_id_count_distinct:count_distinct(project_id), group_by(project_id)"
       },
       {
         id = "stage-q5223la6"
@@ -3808,34 +3335,18 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "Valid From"
               "2" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -3844,11 +3355,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 15
           inputList = [
@@ -3894,9 +3401,14 @@ resource "observe_dashboard" "redis_monitoring" {
                       fnArgs     = []
                       resolution = "SINGLE"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "keyvalue"
-                    valueField    = "locationId"
+                    valueField    = "A_locationId_count_distinct"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -3916,6 +3428,13 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_locationId_count_distinct"
+              },
+            ]
+            wantBuckets = 1
           }
           renderType     = "TABLE"
           selectedStepId = null
@@ -3924,7 +3443,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3932,10 +3450,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-yoae4ksn"
@@ -3945,10 +3459,104 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "locationId"
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              keyField = [
+                                "locationId",
+                              ]
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count_distinct"
+                                fnArgs     = []
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_locationId_count_distinct"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy = [
+                          "locationId",
+                        ]
+                        id                  = "datasetQueryExpression-binff4a6"
+                        inputSource         = "parentStageInputSource"
+                        lookupActions       = []
+                        summarizeVerb       = "statsby"
+                        summaryFunction     = "count_distinct"
+                        summaryFunctionArgs = []
+                        summaryMode         = "single"
+                        type                = "datasetQueryExpression"
+                        valueColumnId       = "A_locationId_count_distinct"
+                        viewTab             = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-4fjkbpw0"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-binff4a6",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-9lbdqot8"
+              index    = 1
+              isPinned = false
+              opal = [
+                "statsby A_locationId_count_distinct:count_distinct(locationId), group_by(locationId)",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3960,7 +3568,7 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = ""
+        pipeline = "statsby A_locationId_count_distinct:count_distinct(locationId), group_by(locationId)"
       },
       {
         id = "stage-z5l9wra8"
@@ -3976,34 +3584,18 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "Valid From"
               "2" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -4012,11 +3604,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 16
           inputList = [
@@ -4062,9 +3650,14 @@ resource "observe_dashboard" "redis_monitoring" {
                       fnArgs     = []
                       resolution = "SINGLE"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "keyvalue"
-                    valueField    = "location"
+                    valueField    = "A_location_count_distinct"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -4089,6 +3682,13 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_location_count_distinct"
+              },
+            ]
+            wantBuckets = 1
           }
           renderType     = "TABLE"
           selectedStepId = null
@@ -4097,7 +3697,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4105,10 +3704,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-qsc07rzc"
@@ -4118,10 +3713,104 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "location"
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              keyField = [
+                                "location",
+                              ]
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count_distinct"
+                                fnArgs     = []
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_location_count_distinct"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy = [
+                          "location",
+                        ]
+                        id                  = "datasetQueryExpression-r357cpom"
+                        inputSource         = "parentStageInputSource"
+                        lookupActions       = []
+                        summarizeVerb       = "statsby"
+                        summaryFunction     = "count_distinct"
+                        summaryFunctionArgs = []
+                        summaryMode         = "single"
+                        type                = "datasetQueryExpression"
+                        valueColumnId       = "A_location_count_distinct"
+                        viewTab             = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-ildf1kvv"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-r357cpom",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-wmtzyibs"
+              index    = 1
+              isPinned = false
+              opal = [
+                "statsby A_location_count_distinct:count_distinct(location), group_by(location)",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4133,7 +3822,7 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = ""
+        pipeline = "statsby A_location_count_distinct:count_distinct(location), group_by(location)"
       },
       {
         id = "stage-kkg69631"
@@ -4149,34 +3838,18 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "Valid From"
               "2" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -4185,11 +3858,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 17
           inputList = [
@@ -4235,9 +3904,14 @@ resource "observe_dashboard" "redis_monitoring" {
                       fnArgs     = []
                       resolution = "SINGLE"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "keyvalue"
-                    valueField    = "redisVersion"
+                    valueField    = "A_redisVersion_count_distinct"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -4262,6 +3936,13 @@ resource "observe_dashboard" "redis_monitoring" {
               "ResultKindSchema",
             ]
             rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_redisVersion_count_distinct"
+              },
+            ]
+            wantBuckets = 1
           }
           renderType     = "TABLE"
           selectedStepId = null
@@ -4270,7 +3951,6 @@ resource "observe_dashboard" "redis_monitoring" {
             {
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4278,10 +3958,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-6ie65a7p"
@@ -4291,10 +3967,104 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "redisVersion"
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              keyField = [
+                                "redisVersion",
+                              ]
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count_distinct"
+                                fnArgs     = []
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_redisVersion_count_distinct"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy = [
+                          "redisVersion",
+                        ]
+                        id                  = "datasetQueryExpression-p0ybs5qk"
+                        inputSource         = "parentStageInputSource"
+                        lookupActions       = []
+                        summarizeVerb       = "statsby"
+                        summaryFunction     = "count_distinct"
+                        summaryFunctionArgs = []
+                        summaryMode         = "single"
+                        type                = "datasetQueryExpression"
+                        valueColumnId       = "A_redisVersion_count_distinct"
+                        viewTab             = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-uhccjx4v"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-p0ybs5qk",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-pq1mqoym"
+              index    = 1
+              isPinned = false
+              opal = [
+                "statsby A_redisVersion_count_distinct:count_distinct(redisVersion), group_by(redisVersion)",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4306,7 +4076,7 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = ""
+        pipeline = "statsby A_redisVersion_count_distinct:count_distinct(redisVersion), group_by(redisVersion)"
       },
       {
         id = "stage-sblyl8hv"
@@ -4322,35 +4092,18 @@ resource "observe_dashboard" "redis_monitoring" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "1" = "Valid From"
               "2" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -4359,11 +4112,7 @@ resource "observe_dashboard" "redis_monitoring" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 18
           inputList = [
@@ -4400,7 +4149,7 @@ resource "observe_dashboard" "redis_monitoring" {
                 }
                 source = {
                   table = {
-                    field       = "instance_pkey"
+                    field       = "A_instance_pkey_count_distinct"
                     groupFields = []
                     statsBy = {
                       fn = "count"
@@ -4410,8 +4159,12 @@ resource "observe_dashboard" "redis_monitoring" {
                       fnArgs     = []
                       resolution = "AUTO"
                     }
-                    transformType = "timechart"
+                    transformType = "none"
                     type          = "singlefield"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
                   }
                   type = "table"
                 }
@@ -4430,54 +4183,16 @@ resource "observe_dashboard" "redis_monitoring" {
             resultKinds = [
               "ResultKindSchema",
             ]
-            rollup = {}
+            rollup      = {}
+            wantBuckets = 50
           }
           renderType     = "TABLE"
           selectedStepId = null
           serializable   = true
           steps = [
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-a6c5idpy"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customName    = "Input"
               customSummary = "redis"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4485,10 +4200,6 @@ resource "observe_dashboard" "redis_monitoring" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-9glxy3qw"
@@ -4498,10 +4209,102 @@ resource "observe_dashboard" "redis_monitoring" {
               queryPresentation = {}
               type              = "InputStep"
             },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    expressions = [
+                      {
+                        autoResolution = true
+                        columnId       = "instance_pkey"
+                        dataVis = {
+                          config = {
+                            color           = "Default"
+                            colorConfigType = "Color"
+                            fieldConfig = {
+                              unit    = ""
+                              visible = false
+                            }
+                            singleStatLabel = "Instances"
+                            thresholds      = null
+                            type            = "singlefield"
+                          }
+                          source = {
+                            table = {
+                              field       = "A_instance_pkey_count_distinct"
+                              groupFields = []
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count_distinct"
+                                fnArgs     = []
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "singlefield"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "singlevalue"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions        = []
+                        groupBy              = []
+                        id                   = "datasetQueryExpression-o46j02ql"
+                        inputSource          = "parentStageInputSource"
+                        lookupActions        = []
+                        summarizeVerb        = "statsby"
+                        summaryFunction      = "count_distinct"
+                        summaryFunctionArgs  = []
+                        summaryMode          = "over-time"
+                        type                 = "datasetQueryExpression"
+                        valueColumnId        = "A_instance_pkey_count_distinct"
+                        viewTab              = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-w1kwiqbj"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-o46j02ql",
+                    ]
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              datasetQueryId = {
+                ignoreCompress = false
+                queryId        = null
+                resultKinds = [
+                  "ResultKindSchema",
+                  "ResultKindData",
+                  "ResultKindStats",
+                ]
+              }
+              id       = "step-07s84q32"
+              index    = 1
+              isPinned = false
+              opal = [
+                "timechart options(empty_bins:true), A_instance_pkey_count_distinct:count_distinct(instance_pkey), group_by()",
+              ]
+              queryPresentation = {}
+              type              = "unknown"
+            },
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4513,7 +4316,7 @@ resource "observe_dashboard" "redis_monitoring" {
           }
         }
         params   = null
-        pipeline = ""
+        pipeline = "timechart options(empty_bins:true), A_instance_pkey_count_distinct:count_distinct(instance_pkey), group_by()"
       },
     ]
   )

--- a/service/redis/db_singelton.tf
+++ b/service/redis/db_singelton.tf
@@ -1,4 +1,4 @@
-# terraform import observe_dashboard.redis_instance_v2 41743168
+# terraform import observe_dashboard.redis_instance 42909070
 resource "observe_dashboard" "redis_instance_v2" {
   description = local.dashboard_description_singleton
   layout = jsonencode(
@@ -10,29 +10,25 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "card-ll37bbel"
+              id       = "card-eemom99l"
               title    = "Dashboard Content"
             }
             items = [
               {
                 card = {
                   cardType    = "parameter"
-                  id          = "card-ve17w7ql"
+                  id          = "card-0aq6hhmv"
                   parameterId = "redis"
                 }
                 layout = {
-                  h           = 4
-                  i           = "card-ve17w7ql"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
+                  h = 4
+                  i = "card-0aq6hhmv"
                   resizeHandles = [
                     "e",
                   ]
-                  static = false
-                  w      = 4
-                  x      = 0
-                  y      = 0
+                  w = 4
+                  x = 0
+                  y = 0
                 }
               },
             ]
@@ -41,44 +37,36 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-oaa8j6kq"
+              id       = "card-60lg2aqn"
               title    = "Memory & CPU"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-njbtt6ok"
+                  id       = "card-fmn50o5v"
                   stageId  = "stage-0ho2ak92"
                 }
                 layout = {
-                  h           = 8
-                  i           = "card-njbtt6ok"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 6
-                  x           = 0
-                  y           = 0
+                  h = 8
+                  i = "card-fmn50o5v"
+                  w = 6
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-483oye1k"
+                  id       = "card-l33i141z"
                   stageId  = "stage-kblmpc8o"
                 }
                 layout = {
-                  h           = 8
-                  i           = "card-483oye1k"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 6
-                  x           = 6
-                  y           = 0
+                  h = 8
+                  i = "card-l33i141z"
+                  w = 6
+                  x = 6
+                  y = 0
                 }
               },
             ]
@@ -87,62 +75,50 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-nd8q4myb"
+              id       = "card-nucrccym"
               title    = "Network & Connections"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-65zx3ap9"
+                  id       = "card-kpwo1cm4"
                   stageId  = "stage-kuf5r7f3"
                 }
                 layout = {
-                  h           = 10
-                  i           = "card-65zx3ap9"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 0
-                  y           = 0
+                  h = 10
+                  i = "card-kpwo1cm4"
+                  w = 4
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-c3w5whl3"
+                  id       = "card-mp1k4f73"
                   stageId  = "stage-xbo28v7v"
                 }
                 layout = {
-                  h           = 10
-                  i           = "card-c3w5whl3"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 4
-                  y           = 0
+                  h = 10
+                  i = "card-mp1k4f73"
+                  w = 4
+                  x = 4
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-3jsqv0cj"
+                  id       = "card-4k68ccly"
                   stageId  = "stage-kp5jhjdv"
                 }
                 layout = {
-                  h           = 10
-                  i           = "card-3jsqv0cj"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 8
-                  y           = 0
+                  h = 10
+                  i = "card-4k68ccly"
+                  w = 4
+                  x = 8
+                  y = 0
                 }
               },
             ]
@@ -151,62 +127,50 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-dgbwgl03"
+              id       = "card-d1dtmmel"
               title    = "Commands"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-c8fm3s2a"
+                  id       = "card-d302luc9"
                   stageId  = "stage-r3msr1xk"
                 }
                 layout = {
-                  h           = 17
-                  i           = "card-c8fm3s2a"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 8
-                  y           = 0
+                  h = 17
+                  i = "card-d302luc9"
+                  w = 4
+                  x = 8
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-0ofx2hd3"
+                  id       = "card-qoptv89o"
                   stageId  = "stage-8ibk9wow"
                 }
                 layout = {
-                  h           = 9
-                  i           = "card-0ofx2hd3"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 8
-                  x           = 0
-                  y           = 0
+                  h = 9
+                  i = "card-qoptv89o"
+                  w = 8
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-3o5u6gxo"
+                  id       = "card-4vgbbm8x"
                   stageId  = "stage-9mulnsts"
                 }
                 layout = {
-                  h           = 8
-                  i           = "card-3o5u6gxo"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 8
-                  x           = 0
-                  y           = 9
+                  h = 8
+                  i = "card-4vgbbm8x"
+                  w = 8
+                  x = 0
+                  y = 9
                 }
               },
             ]
@@ -215,98 +179,78 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = false
-              id       = "section-th0miqd8"
+              id       = "card-2906a7i8"
               title    = "Keys"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-7g60of0m"
+                  id       = "card-ppp9uaqi"
                   stageId  = "stage-ehr1gzq0"
                 }
                 layout = {
-                  h           = 22
-                  i           = "card-7g60of0m"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 6
-                  x           = 0
-                  y           = 0
+                  h = 22
+                  i = "card-ppp9uaqi"
+                  w = 6
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-rvkvgo40"
+                  id       = "card-t41afjsy"
                   stageId  = "stage-yothkrri"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-rvkvgo40"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 6
-                  y           = 0
+                  h = 11
+                  i = "card-t41afjsy"
+                  w = 3
+                  x = 6
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-9mwr2q64"
+                  id       = "card-jz4k06sk"
                   stageId  = "stage-wds98m8p"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-9mwr2q64"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 9
-                  y           = 0
+                  h = 11
+                  i = "card-jz4k06sk"
+                  w = 3
+                  x = 9
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-z148u0h2"
+                  id       = "card-7r7h0ptr"
                   stageId  = "stage-yb1taje8"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-z148u0h2"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 6
-                  y           = 11
+                  h = 11
+                  i = "card-7r7h0ptr"
+                  w = 3
+                  x = 6
+                  y = 11
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-vr1h2bz0"
+                  id       = "card-m9h9a3cy"
                   stageId  = "stage-t1p8enlp"
                 }
                 layout = {
-                  h           = 11
-                  i           = "card-vr1h2bz0"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 9
-                  y           = 11
+                  h = 11
+                  i = "card-m9h9a3cy"
+                  w = 3
+                  x = 9
+                  y = 11
                 }
               },
             ]
@@ -315,62 +259,50 @@ resource "observe_dashboard" "redis_instance_v2" {
             card = {
               cardType = "section"
               closed   = true
-              id       = "section-pit132ks"
+              id       = "card-ovvwcpos"
               title    = "Details"
             }
             items = [
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-6oehbzvm"
+                  id       = "card-btjhzxy5"
                   stageId  = "stage-pajoygss"
                 }
                 layout = {
-                  h           = 14
-                  i           = "card-6oehbzvm"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 2
-                  x           = 0
-                  y           = 0
+                  h = 14
+                  i = "card-btjhzxy5"
+                  w = 2
+                  x = 0
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-tqy84zjl"
+                  id       = "card-siehy6sb"
                   stageId  = "stage-zmb32x6w"
                 }
                 layout = {
-                  h           = 14
-                  i           = "card-tqy84zjl"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 3
-                  x           = 2
-                  y           = 0
+                  h = 14
+                  i = "card-siehy6sb"
+                  w = 3
+                  x = 2
+                  y = 0
                 }
               },
               {
                 card = {
                   cardType = "stage"
-                  id       = "card-ig4axjv0"
+                  id       = "card-gsvpxa0v"
                   stageId  = "stage-rp98umdc"
                 }
                 layout = {
-                  h           = 14
-                  i           = "card-ig4axjv0"
-                  isDraggable = true
-                  isResizable = true
-                  moved       = false
-                  static      = false
-                  w           = 4
-                  x           = 5
-                  y           = 0
+                  h = 14
+                  i = "card-gsvpxa0v"
+                  w = 4
+                  x = 5
+                  y = 0
                 }
               },
             ]
@@ -413,9 +345,9 @@ resource "observe_dashboard" "redis_instance_v2" {
             viewType = "resource-input"
           },
         ]
-        selectedStageId = "stage-rp98umdc"
+        selectedStageId = "stage-kuf5r7f3"
         timeRange = {
-          display               = "Today 15:04:48 → 16:04:48"
+          display               = "Past 60 minutes"
           endTime               = null
           millisFromCurrentTime = 3600000
           originalDisplay       = "Past 60 minutes"
@@ -479,58 +411,31 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = false
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "1" = "Valid From"
-              "2" = "Valid To"
+              "0" = "Valid From"
+              "1" = "Valid To"
             }
             columnVisibility = {
               _c_nodes_path  = false
               _c_nodes_value = false
               instance_pkey  = false
             }
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = true
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 144
-            tableView                  = "TABULAR"
+            tableHeight = 144
           }
           index = 0
           inputList = [
@@ -545,9 +450,14 @@ resource "observe_dashboard" "redis_instance_v2" {
           managers = [
             {
               id                     = "ngwgqnkj"
-              isDisabled             = true
+              isDisabled             = false
               isResourceCountEnabled = false
               type                   = "Timescrubber"
+            },
+            {
+              id         = "c27at1lt"
+              isDisabled = false
+              type       = "JsonTree"
             },
           ]
           queryPresentation = {
@@ -571,47 +481,8 @@ resource "observe_dashboard" "redis_instance_v2" {
           serializable   = true
           steps = [
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-cl17529h"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customName    = "Input"
               customSummary = "test_gcp_learning-bedbug/Redis Instance"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -619,10 +490,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-mb5wx51n"
@@ -633,46 +500,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-ch7996ng"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -680,10 +508,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-lu1es50a"
@@ -708,7 +532,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -724,10 +547,10 @@ resource "observe_dashboard" "redis_instance_v2" {
                     filter instance_pkey = $redis.instance_pkey
                     
                     pick_col
-                    	@."Valid From",
-                     	@."Valid To",
-                     	instance_pkey,
-                     	nodes
+                      @."Valid From",
+                      @."Valid To",
+                      instance_pkey,
+                      nodes
                     
                     flatten_single nodes
                     make_col Node:string(_c_nodes_value.id)
@@ -748,54 +571,27 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "1" = "Valid From"
-              "2" = "Valid To"
+              "0" = "Valid From"
+              "1" = "Valid To"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 285
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = true
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 1
           inputList = [
@@ -810,14 +606,14 @@ resource "observe_dashboard" "redis_instance_v2" {
           managers = [
             {
               id                     = "d3jh1epf"
-              isDisabled             = true
+              isDisabled             = false
               isResourceCountEnabled = false
               type                   = "Timescrubber"
             },
             {
-              id         = "a05ez3f0"
-              isDisabled = true
-              type       = "Vis"
+              id         = "5dt0427i"
+              isDisabled = false
+              type       = "JsonTree"
             },
           ]
           queryPresentation = {
@@ -841,47 +637,8 @@ resource "observe_dashboard" "redis_instance_v2" {
           serializable   = true
           steps = [
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-5ki8kjwf"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customName    = "Input"
               customSummary = "test_gcp_learning-bedbug/Redis Instance"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -889,10 +646,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-khwznicp"
@@ -903,46 +656,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {
-                  authorizedNetwork     = "count"
-                  connectMode           = "count"
-                  createTime            = "count"
-                  currentLocationId     = "count"
-                  displayName           = "count"
-                  host                  = "count"
-                  instance_pkey         = "count"
-                  location              = "count"
-                  locationId            = "count"
-                  name                  = "count"
-                  nodes                 = "count"
-                  persistenceMode       = "count"
-                  port                  = "count"
-                  project_id            = "count"
-                  readReplicasMode      = "count"
-                  redisVersion          = "count"
-                  replicaCount          = "count"
-                  reservedIpRange       = "count"
-                  state                 = "count"
-                  tier                  = "count"
-                  transitEncryptionMode = "count"
-                  ttl                   = "count"
-                  version               = "count"
-                }
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-g0a7e318"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -950,10 +664,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-599xhajb"
@@ -969,7 +679,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -982,7 +691,7 @@ resource "observe_dashboard" "redis_instance_v2" {
         }
         params   = null
         pipeline = <<-EOT
-                    filter instance_pkey = $redis.instance_pkey 
+                    filter instance_pkey = $redis.instance_pkey
                 EOT
       },
       {
@@ -1006,54 +715,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 2
           inputList = [
@@ -1105,7 +788,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_commands_calls_1zbspxjt"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1123,15 +806,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "commands_calls_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1139,10 +821,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-61yyniv6"
@@ -1154,7 +832,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1162,10 +839,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-k6lo3wnn"
@@ -1182,7 +855,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1221,54 +893,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 3
           inputList = [
@@ -1320,7 +966,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_commands_total_time_1vx369kl"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1338,15 +984,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "commands_total_time_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1354,10 +999,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-v2jud9qz"
@@ -1369,7 +1010,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1377,10 +1017,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-903u02hd"
@@ -1398,7 +1034,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1438,54 +1073,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 4
           inputList = [
@@ -1537,7 +1146,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_commands_usec_per_call_ywai7d9t"
                   }
                   topK = {
-                    k     = 16
+                    k     = 33
                     order = "Top"
                     type  = "Auto"
                   }
@@ -1555,15 +1164,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 300
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "commands_usec_per_call_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1571,10 +1179,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-kni8afq7"
@@ -1586,7 +1190,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1594,10 +1197,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-a6cr9jme"
@@ -1615,7 +1214,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1640,7 +1238,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "keyspace_keys_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "keyspace_keys_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -1655,54 +1253,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index     = 5
           inputList = []
@@ -1726,6 +1298,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
+                    unit    = "1"
                     visible = true
                   }
                 }
@@ -1755,7 +1328,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
@@ -1763,7 +1336,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1771,10 +1343,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-57tod424"
@@ -1804,6 +1372,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                               visible = true
                             }
                             yConfig = {
+                              unit    = "1"
                               visible = true
                             }
                           }
@@ -1823,7 +1392,8 @@ resource "observe_dashboard" "redis_instance_v2" {
                           }
                           type = "timeseries"
                         }
-                        disableAggregate = false
+                        disableAggregate     = false
+                        expressionIdentifier = "A"
                         filterActions = [
                           {
                             params = {
@@ -1849,12 +1419,14 @@ resource "observe_dashboard" "redis_instance_v2" {
                           },
                           {
                             params = {
-                              columnId    = "role"
-                              columnType  = "string"
-                              filterVerb  = "filter"
-                              isExcluding = false
+                              columnId   = "role"
+                              columnType = "string"
+                              filterVerb = "filter"
                               values = [
-                                "primary",
+                                {
+                                  isExcluding = false
+                                  value       = "primary"
+                                },
                               ]
                             }
                             summary = null
@@ -1875,7 +1447,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                                                         Number of keys stored in this database.
                                                     EOT
                           heuristics  = null
-                          interval    = null
                           name        = "keyspace_keys"
                           rollup      = "avg"
                           type        = "gauge"
@@ -1903,16 +1474,26 @@ resource "observe_dashboard" "redis_instance_v2" {
                         summaryMode    = "over-time"
                         type           = "metricExpression"
                         valueColumnId  = "metric_keyspace_keys_6fdw8por"
+                        viewTab        = "visualize"
                       },
                     ]
-                    selectedExpressionId = "metricExpression-uwlpmugf"
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-k9lrilcq"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-uwlpmugf",
+                    ]
                   }
                 }
                 summary = null
                 type    = "ExpressionBuilder"
               }
               customSummary = "Expression Builder"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -1920,10 +1501,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-85clp81i"
@@ -1941,12 +1518,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = <<-EOT
-                            exists instance_pkey = @"filter_Redis Instance".instance_pkey
-                            filter role = "primary"
-                            align frame(back: 2m), metric_keyspace_keys_6fdw8por:avg(m("keyspace_keys"))
-                            aggregate metric_keyspace_keys_6fdw8por:sum(metric_keyspace_keys_6fdw8por), group_by(instance_pkey)
-                        EOT
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -1971,7 +1542,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "stats_expired_keys_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "stats_expired_keys_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -1986,35 +1557,19 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -2023,11 +1578,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index     = 6
           inputList = []
@@ -2051,6 +1602,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
+                    unit    = "1"
                     visible = true
                   }
                 }
@@ -2065,7 +1617,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_stats_expired_keys_clr7f3tz"
                   }
                   topK = {
-                    k     = 16
+                    k     = 100
                     order = "Top"
                     type  = "Auto"
                   }
@@ -2083,7 +1635,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
@@ -2091,7 +1643,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2099,10 +1650,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-1ggmqaco"
@@ -2132,6 +1679,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                               visible = true
                             }
                             yConfig = {
+                              unit    = "1"
                               visible = true
                             }
                           }
@@ -2153,7 +1701,8 @@ resource "observe_dashboard" "redis_instance_v2" {
                           }
                           type = "timeseries"
                         }
-                        disableAggregate = false
+                        disableAggregate     = false
+                        expressionIdentifier = "A"
                         filterActions = [
                           {
                             params = {
@@ -2179,12 +1728,14 @@ resource "observe_dashboard" "redis_instance_v2" {
                           },
                           {
                             params = {
-                              columnId    = "role"
-                              columnType  = "string"
-                              filterVerb  = "filter"
-                              isExcluding = false
+                              columnId   = "role"
+                              columnType = "string"
+                              filterVerb = "filter"
                               values = [
-                                "primary",
+                                {
+                                  isExcluding = false
+                                  value       = "primary"
+                                },
                               ]
                             }
                             summary = null
@@ -2299,7 +1850,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                               "Redis Instance",
                             ]
                           }
-                          interval    = null
                           name        = "stats_expired_keys"
                           rollup      = "avg"
                           type        = "delta"
@@ -2327,16 +1877,26 @@ resource "observe_dashboard" "redis_instance_v2" {
                         summaryMode    = "over-time"
                         type           = "metricExpression"
                         valueColumnId  = "metric_stats_expired_keys_clr7f3tz"
+                        viewTab        = "visualize"
                       },
                     ]
-                    selectedExpressionId = "metricExpression-y2pkuirl"
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-ghg2aypo"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-y2pkuirl",
+                    ]
                   }
                 }
                 summary = null
                 type    = "ExpressionBuilder"
               }
               customSummary = "Expression Builder"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2344,10 +1904,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-mnw0khml"
@@ -2365,7 +1921,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2390,7 +1945,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "stats_keyspace_hits_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "stats_keyspace_hits_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -2405,54 +1960,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "0" = "valid_from"
               "1" = "valid_to"
               "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index     = 7
           inputList = []
@@ -2476,6 +2005,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
+                    unit    = "1"
                     visible = true
                   }
                 }
@@ -2505,7 +2035,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
@@ -2513,7 +2043,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2521,10 +2050,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-n39fgge3"
@@ -2554,6 +2079,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                               visible = true
                             }
                             yConfig = {
+                              unit    = "1"
                               visible = true
                             }
                           }
@@ -2573,7 +2099,8 @@ resource "observe_dashboard" "redis_instance_v2" {
                           }
                           type = "timeseries"
                         }
-                        disableAggregate = false
+                        disableAggregate     = false
+                        expressionIdentifier = "A"
                         filterActions = [
                           {
                             params = {
@@ -2599,12 +2126,14 @@ resource "observe_dashboard" "redis_instance_v2" {
                           },
                           {
                             params = {
-                              columnId    = "role"
-                              columnType  = "string"
-                              filterVerb  = "filter"
-                              isExcluding = false
+                              columnId   = "role"
+                              columnType = "string"
+                              filterVerb = "filter"
                               values = [
-                                "primary",
+                                {
+                                  isExcluding = false
+                                  value       = "primary"
+                                },
                               ]
                             }
                             summary = null
@@ -2717,7 +2246,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                               "Redis Instance",
                             ]
                           }
-                          interval    = null
                           name        = "stats_keyspace_hits"
                           rollup      = "avg"
                           type        = "delta"
@@ -2745,16 +2273,26 @@ resource "observe_dashboard" "redis_instance_v2" {
                         summaryMode    = "over-time"
                         type           = "metricExpression"
                         valueColumnId  = "metric_stats_keyspace_hits_n6hey7pl"
+                        viewTab        = "visualize"
                       },
                     ]
-                    selectedExpressionId = "metricExpression-7br0iwuc"
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-uvatl4wg"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-7br0iwuc",
+                    ]
                   }
                 }
                 summary = null
                 type    = "ExpressionBuilder"
               }
               customSummary = "Expression Builder"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2762,10 +2300,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-hid85kwz"
@@ -2783,7 +2317,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -2808,7 +2341,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "stats_keyspace_misses_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "stats_keyspace_misses_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -2823,54 +2356,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "0" = "valid_from"
               "1" = "valid_to"
               "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index     = 8
           inputList = []
@@ -2894,6 +2401,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
+                    unit    = "1"
                     visible = true
                   }
                 }
@@ -2923,7 +2431,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 100
           }
           selectedStepId = null
           serializable   = true
@@ -2931,7 +2439,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -2939,10 +2446,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-38d44nsv"
@@ -2972,6 +2475,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                               visible = true
                             }
                             yConfig = {
+                              unit    = "1"
                               visible = true
                             }
                           }
@@ -2991,7 +2495,8 @@ resource "observe_dashboard" "redis_instance_v2" {
                           }
                           type = "timeseries"
                         }
-                        disableAggregate = false
+                        disableAggregate     = false
+                        expressionIdentifier = "A"
                         filterActions = [
                           {
                             params = {
@@ -3017,12 +2522,14 @@ resource "observe_dashboard" "redis_instance_v2" {
                           },
                           {
                             params = {
-                              columnId    = "role"
-                              columnType  = "string"
-                              filterVerb  = "filter"
-                              isExcluding = false
+                              columnId   = "role"
+                              columnType = "string"
+                              filterVerb = "filter"
                               values = [
-                                "primary",
+                                {
+                                  isExcluding = false
+                                  value       = "primary"
+                                },
                               ]
                             }
                             summary = null
@@ -3135,7 +2642,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                               "Redis Instance",
                             ]
                           }
-                          interval    = null
                           name        = "stats_keyspace_misses"
                           rollup      = "avg"
                           type        = "delta"
@@ -3163,16 +2669,26 @@ resource "observe_dashboard" "redis_instance_v2" {
                         summaryMode    = "over-time"
                         type           = "metricExpression"
                         valueColumnId  = "metric_stats_keyspace_misses_f1jy5fad"
+                        viewTab        = "visualize"
                       },
                     ]
-                    selectedExpressionId = "metricExpression-x9m3dor7"
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-7b9g6ov5"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-x9m3dor7",
+                    ]
                   }
                 }
                 summary = null
                 type    = "ExpressionBuilder"
               }
               customSummary = "Expression Builder"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3180,10 +2696,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-m8zamc7f"
@@ -3201,7 +2713,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3241,36 +2752,19 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
               "0" = "valid_from"
               "1" = "valid_to"
               "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -3279,11 +2773,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 9
           inputList = [
@@ -3355,15 +2845,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 250
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "stats_cache_hit_ratio_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3371,10 +2860,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-swky5537"
@@ -3385,22 +2870,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {}
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-sj1hjvzb"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3408,10 +2878,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-fwbjsxzv"
@@ -3429,7 +2895,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3469,35 +2934,19 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -3506,11 +2955,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 10
           inputList = [
@@ -3561,7 +3006,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_stats_memory_usage_ratio_753dc9fz"
                   }
                   topK = {
-                    k     = 16
+                    k     = 40
                     order = "Top"
                     type  = "Auto"
                   }
@@ -3579,15 +3024,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 250
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "stats_memory_usage_ratio_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3595,10 +3039,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-y1rvwqst"
@@ -3610,7 +3050,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3618,10 +3057,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-m2w6vlvm"
@@ -3639,7 +3074,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3679,38 +3113,21 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "space"
-              "2" = "valid_from"
-              "3" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
+              "3" = "space"
               "4" = "relationship"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -3719,11 +3136,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 11
           inputList = [
@@ -3776,7 +3189,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_stats_cpu_utilization_790asu9w"
                   }
                   topK = {
-                    k     = 16
+                    k     = 40
                     order = "Top"
                     type  = "Auto"
                   }
@@ -3800,15 +3213,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 250
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "stats_cpu_utilization_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3816,10 +3228,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-sh6p4bbf"
@@ -3831,7 +3239,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -3839,10 +3246,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-ljtf2g9w"
@@ -3860,7 +3263,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -3885,7 +3287,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "stats_network_traffic_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "stats_network_traffic_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -3900,35 +3302,19 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               anchoredCellSelection   = null
               anchoredColumnSelection = null
@@ -3943,15 +3329,24 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                    = {}
               selectionType           = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
-          index     = 12
-          inputList = []
-          label     = "Total number of bytes sent to/from redis"
+          index = 12
+          inputList = [
+            {
+              datasetId   = local.redis_metrics
+              inputName   = "stats_network_traffic_from_GCP/Redis Metrics"
+              inputRole   = "Data"
+              isUserInput = true
+            },
+            {
+              inputName   = "filter_Redis Instance"
+              inputRole   = "Data"
+              isUserInput = true
+              stageId     = "stage-jt6xxmm2"
+            },
+          ]
+          label = "Total number of bytes sent to/from redis"
           managers = [
             {
               id         = "qsgn01tt"
@@ -3971,8 +3366,9 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
-                    unit    = "bytes"
-                    visible = true
+                    axisLabel = "Bytes/Second"
+                    unit      = "By"
+                    visible   = true
                   }
                 }
                 source = {
@@ -3986,7 +3382,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_stats_network_traffic_qe2motyy"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -4004,15 +3400,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "stats_network_traffic_from_GCP/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4020,10 +3415,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-l6ig60kz"
@@ -4034,223 +3425,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              action = {
-                params = {
-                  expressionList = {
-                    expressions = [
-                      {
-                        dataVis = {
-                          config = {
-                            color         = "Default"
-                            hideGridLines = false
-                            legend = {
-                              placement = "right"
-                              type      = "list"
-                              visible   = false
-                            }
-                            type = "xy"
-                            xConfig = {
-                              visible = true
-                            }
-                            yConfig = {
-                              unit    = "bytes"
-                              visible = true
-                            }
-                          }
-                          source = {
-                            table = {
-                              groupFields = [
-                                "instance_pkey",
-                              ]
-                              transformType = "none"
-                              type          = "xy"
-                              x             = "valid_from"
-                              y             = "metric_stats_network_traffic_qe2motyy"
-                            }
-                            topK = {
-                              order = "Top"
-                              type  = "Auto"
-                            }
-                            type = "table"
-                          }
-                          type = "timeseries"
-                        }
-                        disableAggregate = false
-                        filterActions = [
-                          {
-                            params = {
-                              foreignKey = {
-                                __typename = "ForeignKey"
-                                dstFields = [
-                                  "instance_pkey",
-                                ]
-                                label = "Redis Instance"
-                                srcFields = [
-                                  "instance_pkey",
-                                ]
-                                targetDataset    = local.redis_instance
-                                targetStageLabel = null
-                                type             = "foreign"
-                              }
-                              joinInput = {
-                                stageId = "stage-jt6xxmm2"
-                              }
-                            }
-                            summary = null
-                            type    = "ExistsInFilter"
-                          },
-                        ]
-                        frameDuration = {
-                          num  = 2
-                          unit = "minute"
-                        }
-                        groupBy = [
-                          "instance_pkey",
-                        ]
-                        id            = "metricExpression-v29zhmyn"
-                        lookupActions = []
-                        metric = {
-                          aggregate   = "sum"
-                          datasetId   = local.redis_metrics
-                          description = <<-EOT
-                                                        Total number of bytes sent to/from redis includes bytes from commands themselves, payload data, and delimiters.
-                                                    EOT
-                          heuristics = {
-                            __typename = "MetricHeuristics"
-                            tags = [
-                              {
-                                __typename = "MetricTag"
-                                column     = "displayName"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "hostname"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "instance_pkey"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "region"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "role"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "label"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_category"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_kind"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_kind_text"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_type"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "project_id"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "value_type"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "value_type_text"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "command"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "relationship"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "space"
-                                path       = ""
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_labels"
-                                path       = "direction"
-                              },
-                              {
-                                __typename = "MetricTag"
-                                column     = "metric_labels"
-                                path       = "role"
-                              },
-                            ]
-                            validLinkLabels = [
-                              "Redis Instance",
-                            ]
-                          }
-                          interval    = null
-                          name        = "stats_network_traffic"
-                          rollup      = "avg"
-                          type        = "delta"
-                          unit        = "By"
-                          userDefined = true
-                        }
-                        metricLink = {
-                          __typename = "ForeignKey"
-                          dstFields = [
-                            "instance_pkey",
-                          ]
-                          label = "Redis Instance"
-                          srcFields = [
-                            "instance_pkey",
-                          ]
-                          targetDataset    = local.redis_instance
-                          targetStageLabel = null
-                          type             = "foreign"
-                        }
-                        metricLinkInputSource = {
-                          stageId = "stage-jt6xxmm2"
-                        }
-                        showAlignment  = false
-                        showResolution = false
-                        summaryMode    = "over-time"
-                        type           = "metricExpression"
-                        valueColumnId  = "metric_stats_network_traffic_qe2motyy"
-                      },
-                    ]
-                    selectedExpressionId = "metricExpression-v29zhmyn"
-                  }
-                }
-                summary = null
-                type    = "ExpressionBuilder"
-              }
-              customSummary = "Expression Builder"
-              datasetQuery  = null
+              customSummary = ""
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4259,17 +3434,13 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindData",
                   "ResultKindStats",
                 ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
-                ]
               }
-              id       = "step-0w3u5geq"
+              id       = "step-23je2ank"
               index    = 1
               isPinned = false
               opal = [
                 "exists instance_pkey = @\"filter_Redis Instance\".instance_pkey",
-                "align frame(back: 2m), metric_stats_network_traffic_qe2motyy:avg(m(\"stats_network_traffic\"))",
+                "align metric_stats_network_traffic_qe2motyy:rate(m(\"stats_network_traffic\"))",
                 "aggregate metric_stats_network_traffic_qe2motyy:sum(metric_stats_network_traffic_qe2motyy), group_by(instance_pkey)",
               ]
               queryPresentation = {}
@@ -4278,7 +3449,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4292,7 +3462,7 @@ resource "observe_dashboard" "redis_instance_v2" {
         params   = null
         pipeline = <<-EOT
                     exists instance_pkey = @"filter_Redis Instance".instance_pkey
-                    align frame(back: 2m), metric_stats_network_traffic_qe2motyy:avg(m("stats_network_traffic"))
+                    align metric_stats_network_traffic_qe2motyy:rate(m("stats_network_traffic"))
                     aggregate metric_stats_network_traffic_qe2motyy:sum(metric_stats_network_traffic_qe2motyy), group_by(instance_pkey)
                 EOT
       },
@@ -4302,7 +3472,7 @@ resource "observe_dashboard" "redis_instance_v2" {
           {
             datasetId   = local.redis_metrics
             datasetPath = null
-            inputName   = "stats_connections_total_from_test_gcp_learning-bedbug/Redis Metrics"
+            inputName   = "stats_connections_total_from_GCP/Redis Metrics"
             inputRole   = "Data"
             stageId     = null
           },
@@ -4317,54 +3487,28 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index     = 13
           inputList = []
@@ -4388,7 +3532,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     visible = true
                   }
                   yConfig = {
-                    unit    = "bytes"
+                    unit    = "1"
                     visible = true
                   }
                 }
@@ -4418,15 +3562,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
-          selectedStepId = "step-wd5qezql"
+          selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4434,10 +3577,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-4l56kbzu"
@@ -4467,7 +3606,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                               visible = true
                             }
                             yConfig = {
-                              unit    = "bytes"
+                              unit    = "1"
                               visible = true
                             }
                           }
@@ -4487,7 +3626,8 @@ resource "observe_dashboard" "redis_instance_v2" {
                           }
                           type = "timeseries"
                         }
-                        disableAggregate = false
+                        disableAggregate     = false
+                        expressionIdentifier = "A"
                         filterActions = [
                           {
                             params = {
@@ -4618,7 +3758,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                               "Redis Instance",
                             ]
                           }
-                          interval    = null
                           name        = "stats_connections_total"
                           rollup      = "avg"
                           type        = "delta"
@@ -4646,16 +3785,26 @@ resource "observe_dashboard" "redis_instance_v2" {
                         summaryMode    = "over-time"
                         type           = "metricExpression"
                         valueColumnId  = "metric_stats_connections_total_0ajegqu4"
+                        viewTab        = "visualize"
                       },
                     ]
-                    selectedExpressionId = "metricExpression-v29zhmyn"
+                    multiExpression = {
+                      expressionIdentifier = "A"
+                      filterActions        = []
+                      id                   = "multiExpression-4vdg1na7"
+                      lookupActions        = []
+                      type                 = "multiExpression"
+                      viewTab              = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-v29zhmyn",
+                    ]
                   }
                 }
                 summary = null
                 type    = "ExpressionBuilder"
               }
               customSummary = "Expression Builder"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4663,10 +3812,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-wd5qezql"
@@ -4683,11 +3828,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = <<-EOT
-                            exists instance_pkey = @"filter_Redis Instance".instance_pkey
-                            align frame(back: 2m), metric_stats_connections_total_0ajegqu4:avg(m("stats_connections_total"))
-                            aggregate metric_stats_connections_total_0ajegqu4:sum(metric_stats_connections_total_0ajegqu4), group_by()
-                        EOT
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4726,35 +3866,19 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "0" = "instance_pkey"
-              "1" = "valid_from"
-              "2" = "valid_to"
+              "0" = "valid_from"
+              "1" = "valid_to"
+              "2" = "instance_pkey"
             }
-            columnVisibility             = {}
-            columnWidths                 = {}
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = false
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnVisibility            = {}
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
               cells                = {}
               columnSelectSequence = []
@@ -4763,11 +3887,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               rows                 = {}
               selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 14
           inputList = [
@@ -4818,7 +3938,7 @@ resource "observe_dashboard" "redis_instance_v2" {
                     y             = "metric_clients_connected_e3qjll1a"
                   }
                   topK = {
-                    k     = 16
+                    k     = 66
                     order = "Top"
                     type  = "Auto"
                   }
@@ -4836,15 +3956,14 @@ resource "observe_dashboard" "redis_instance_v2" {
               "ResultKindSchema",
             ]
             rollup      = {}
-            wantBuckets = 600
+            wantBuckets = 150
           }
           selectedStepId = null
           serializable   = true
           steps = [
             {
               customName    = "Input"
-              customSummary = ""
-              datasetQuery  = null
+              customSummary = "clients_connected_from_test_gcp_learning-bedbug/Redis Metrics"
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4852,10 +3971,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-6xc2yfb9"
@@ -4867,7 +3982,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             },
             {
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -4875,10 +3989,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-d0f4t8o4"
@@ -4896,7 +4006,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -4929,57 +4038,30 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "1" = "Valid From"
-              "2" = "Valid To"
+              "0" = "Valid From"
+              "1" = "Valid To"
             }
             columnVisibility = {
               _c_instance_properties_path = false
               instance_pkey               = false
             }
-            columnWidths                 = {}
-            containerWidth               = 2143
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = true
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            columnWidths                = {}
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 15
           inputList = [
@@ -4994,14 +4076,14 @@ resource "observe_dashboard" "redis_instance_v2" {
           managers = [
             {
               id                     = "874dqnjh"
-              isDisabled             = true
+              isDisabled             = false
               isResourceCountEnabled = false
               type                   = "Timescrubber"
             },
             {
-              id         = "1cw8fys5"
-              isDisabled = true
-              type       = "Vis"
+              id         = "xupmofha"
+              isDisabled = false
+              type       = "JsonTree"
             },
           ]
           queryPresentation = {
@@ -5027,7 +4109,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = "test_gcp_learning-bedbug/Redis Instance"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -5035,10 +4116,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-ggplevzw"
@@ -5049,22 +4126,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {}
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-tmp5uw00"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -5072,10 +4134,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-4q606eh4"
@@ -5101,7 +4159,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -5121,9 +4178,9 @@ resource "observe_dashboard" "redis_instance_v2" {
                     flatten instance_properties
                     
                     pick_col
-                    	@."Valid From",
-                     	@."Valid To",
-                      	instance_pkey,_c_instance_properties_path,
+                      @."Valid From",
+                      @."Valid To",
+                        instance_pkey,_c_instance_properties_path,
                        Property: replace(_c_instance_properties_path,'_',' '),
                        Value: _c_instance_properties_value
                 EOT
@@ -5142,13 +4199,10 @@ resource "observe_dashboard" "redis_instance_v2" {
         layout = {
           appearance = "VISIBLE"
           dataTableViewState = {
-            autoTableHeight    = true
-            columnFooterHeight = 0
-            columnHeaderHeight = 29
             columnOrderOverride = {
-              "1" = "_c_instance_properties_path"
-              "2" = "Valid From"
-              "3" = "Valid To"
+              "0" = "Valid From"
+              "1" = "Valid To"
+              "3" = "_c_instance_properties_path"
             }
             columnVisibility = {
               _c_instance_properties_path = false
@@ -5157,45 +4211,21 @@ resource "observe_dashboard" "redis_instance_v2" {
             columnWidths = {
               Value = 462
             }
-            containerWidth               = 285
-            contextMenuXCoord            = null
-            contextMenuYCoord            = null
-            defaultColumnWidth           = 70
-            disableFixedLeftColumns      = false
-            eventLinkColumnId            = null
-            fetchPageSize                = 100
-            hasCalculatedColumnWidths    = true
-            hasDoneAutoLayout            = false
-            maxColumnWidth               = 600
-            maxMeasuredColumnHeaderWidth = {}
-            maxMeasuredColumnWidth       = {}
-            minColumnWidth               = 60
-            minRowHeight                 = 30
-            preserveCellAndRowSelection  = true
-            rowHeaderWidth               = 20
-            rowHeights                   = {}
-            rowSizeIncrement             = 1
-            scrollToColumn               = null
-            scrollToRow                  = 0
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = {}
+            rowSizing                   = "Compact"
             selection = {
-              anchoredCellSelection   = null
-              anchoredColumnSelection = null
-              anchoredRowSelection    = null
-              cells                   = {}
-              columnSelectSequence    = []
-              columns                 = {}
-              highlightState          = {}
-              lastCellSelection       = null
-              lastColumnSelection     = null
-              lastRowSelection        = null
-              rows                    = {}
-              selectionType           = "table"
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
             }
-            shouldAutoLayout           = false
-            summaryColumnOrderOverride = {}
-            summaryColumnVisibility    = {}
-            tableHeight                = 0
-            tableView                  = "TABULAR"
+            tableHeight = 0
           }
           index = 16
           inputList = [
@@ -5210,14 +4240,14 @@ resource "observe_dashboard" "redis_instance_v2" {
           managers = [
             {
               id                     = "qy4a8j7m"
-              isDisabled             = true
+              isDisabled             = false
               isResourceCountEnabled = false
               type                   = "Timescrubber"
             },
             {
-              id         = "o0c71dzx"
-              isDisabled = true
-              type       = "Vis"
+              id         = "bdxdvm6c"
+              isDisabled = false
+              type       = "JsonTree"
             },
           ]
           queryPresentation = {
@@ -5243,7 +4273,6 @@ resource "observe_dashboard" "redis_instance_v2" {
             {
               customName    = "Input"
               customSummary = "test_gcp_learning-bedbug/Redis Instance"
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -5251,10 +4280,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id                = "step-etkccztz"
@@ -5265,22 +4290,7 @@ resource "observe_dashboard" "redis_instance_v2" {
               type              = "InputStep"
             },
             {
-              columnStatsTable = {
-                columnFunctions = {}
-                datasetQueryId = {
-                  ignoreCompress = false
-                  queryId        = "q-pphydqqk"
-                  resultKinds = [
-                    "ResultKindSchema",
-                    "ResultKindData",
-                  ]
-                  tableTypes = [
-                    "TABULAR",
-                  ]
-                }
-              }
               customSummary = ""
-              datasetQuery  = null
               datasetQueryId = {
                 ignoreCompress = false
                 queryId        = null
@@ -5288,10 +4298,6 @@ resource "observe_dashboard" "redis_instance_v2" {
                   "ResultKindSchema",
                   "ResultKindData",
                   "ResultKindStats",
-                ]
-                tableTypes = [
-                  "TABULAR",
-                  "SUMMARY",
                 ]
               }
               id       = "step-8xlmk08h"
@@ -5317,7 +4323,6 @@ resource "observe_dashboard" "redis_instance_v2" {
           ]
           type = "table"
           viewModel = {
-            consoleValue = null
             railCollapseState = {
               inputsOutputs = false
               minimap       = false
@@ -5337,9 +4342,9 @@ resource "observe_dashboard" "redis_instance_v2" {
                     flatten instance_properties
                     
                     pick_col
-                    	@."Valid From",
-                     	@."Valid To",
-                      	instance_pkey,_c_instance_properties_path,
+                      @."Valid From",
+                      @."Valid To",
+                        instance_pkey,_c_instance_properties_path,
                        Property: replace(_c_instance_properties_path,'_',' '),
                        Value: _c_instance_properties_value
                 EOT


### PR DESCRIPTION
## What does this PR do?

Sets the network traffic-related graphs in redis dashboards to be rates instead of averages

## Motivation

Internal feedback suggested that network traffic in these graphs would make more sense as a rate per second rather than an actual count of how many bytes of traffic there were. 

## Testing

Previewed in staging with a pre-release and it looked good. TFtests pass locally. 
