### PR TITLE
chore: change log interface structured_log keyword

### DIFF
--- a/service/cloudfunctions/logs.tf
+++ b/service/cloudfunctions/logs.tf
@@ -74,7 +74,7 @@ resource "observe_dataset" "cloud_functions_audit_logs" {
         functionName,
         cloudFunctionInstanceAssetKey
 
-      interface "log", "structured_log": protoPayload
+      interface "log", "log": protoPayload
     EOF
   }
 }

--- a/service/storage/logs.tf
+++ b/service/storage/logs.tf
@@ -29,7 +29,7 @@ resource "observe_dataset" "storage_logs" {
         region,
         bucket_name
       
-      interface "log", "structured_log": protoPayload
+      interface "log", "log": protoPayload
     EOF
   }
 }


### PR DESCRIPTION
## What does this PR do?

This changes the deprecated term "structured_log" to "log" on the defined log interface for:
* GCP/Cloud Functions Audit Logs
* GCP/Storage Logs

## Testing

Tested via a pre-release on Content's shared staging instance.
