### PR TITLE
fix: remove and quote bare null column/key names in OPAL

### DIFF
--- a/service/cloudrun/logs.tf
+++ b/service/cloudrun/logs.tf
@@ -23,8 +23,7 @@ resource "observe_dataset" "cloud_run_service_logs" {
         requestMethod:string(httpRequest.requestMethod),
         requestUrl:string(httpRequest.requestUrl),
         responseSize:float64(httpRequest.responseSize),
-        status:int64(httpRequest.status),
-        null:httpRequest.null
+        status:int64(httpRequest.status)
 
       pick_col 
         timestamp,

--- a/service/loadbalancing/loadBalancingDashboard.tf
+++ b/service/loadbalancing/loadBalancingDashboard.tf
@@ -5009,7 +5009,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
                 "    \thealthy:defaultServiceHealthyStatusGroups,",
                 "        unhealthy:defaultServiceUnhealthyStatusGroups,",
                 "        unknown:defaultServiceUnknownStatusGroups,",
-                "        null:defaultServiceNullStatusGroups)",
+                "        \"null\":defaultServiceNullStatusGroups)",
                 "flatten_single backendHealthStates",
                 "",
                 "rename_col ",
@@ -5138,7 +5138,7 @@ resource "observe_dashboard" "load_balancing_monitoring" {
                         	healthy:defaultServiceHealthyStatusGroups,
                             unhealthy:defaultServiceUnhealthyStatusGroups,
                             unknown:defaultServiceUnknownStatusGroups,
-                            null:defaultServiceNullStatusGroups)
+                            "null":defaultServiceNullStatusGroups)
                     flatten_single backendHealthStates
                     
                     rename_col 


### PR DESCRIPTION
## What does this PR do?

Remove unused `null:httpRequest.null` column from Cloud Run service logs dataset, and quote the `null` key in the load balancing dashboard make_object call to avoid bare null identifiers.

## Motivation

We are changing null to be a keyword. This is to make the terraform models forward-compatible.

## Testing

Verified the new OPAL still compiles.
